### PR TITLE
rangeserver: Periodically renew epoch lease in range manager

### DIFF
--- a/rangeserver/src/epoch_provider.rs
+++ b/rangeserver/src/epoch_provider.rs
@@ -12,7 +12,10 @@ pub trait EpochProvider: Send + Sync + 'static {
     // greater than or equal to e-1.
     // In particular this means that the value returned from here could be one less
     // than the true epoch.
-    async fn read_epoch(&self) -> Result<u64, Error>;
+    fn read_epoch(&self) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
 
-    async fn wait_until_epoch(&self, epoch: u64) -> Result<(), Error>;
+    fn wait_until_epoch(
+        &self,
+        epoch: u64,
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 }

--- a/rangeserver/src/persistence.rs
+++ b/rangeserver/src/persistence.rs
@@ -31,38 +31,42 @@ pub enum Error {
 }
 
 pub trait Persistence: Send + Sync + 'static {
-    async fn take_ownership_and_load_range(
+    fn take_ownership_and_load_range(
         &self,
         range_id: FullRangeId,
-    ) -> Result<RangeInfo, Error>;
-    async fn renew_epoch_lease(
+    ) -> impl std::future::Future<Output = Result<RangeInfo, Error>> + Send;
+    fn renew_epoch_lease(
         &self,
         range_id: FullRangeId,
         new_lease: EpochLease,
         leader_sequence_number: u64,
-    ) -> Result<(), Error>;
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
     // TODO: Handle deletes and tombstones in the API too.
-    async fn put_versioned_record(
+    fn put_versioned_record(
         &self,
         range_id: FullRangeId,
         key: Bytes,
         val: Bytes,
         version: KeyVersion,
-    ) -> Result<(), Error>;
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
-    async fn upsert(
+    fn upsert(
         &self,
         range_id: FullRangeId,
         key: Bytes,
         val: Bytes,
         version: KeyVersion,
-    ) -> Result<(), Error>;
-    async fn delete(
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    fn delete(
         &self,
         range_id: FullRangeId,
         key: Bytes,
         version: KeyVersion,
-    ) -> Result<(), Error>;
-    async fn get(&self, range_id: FullRangeId, key: Bytes) -> Result<Option<Bytes>, Error>;
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    fn get(
+        &self,
+        range_id: FullRangeId,
+        key: Bytes,
+    ) -> impl std::future::Future<Output = Result<Option<Bytes>, Error>> + Send;
 }


### PR DESCRIPTION
⚠️  First rust commit, hopefully all is ok ⚠️ 

Add a task that periodically renews the epoch lease in range manager. Commit also includes some type changes to enable State and some async functions to be used in a tokio task.

AFAIK, when requesting a new lease, we should also store the merged lease bounds in the state again.
Added a test as well.