### PR TITLE
Epoch Broadcaster frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,9 @@ dependencies = [
  "machnet",
  "prost",
  "proto",
+ "rand 0.8.5",
  "scylla",
+ "skiplist",
  "strum",
  "thiserror",
  "tokio",
@@ -1450,6 +1452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "skiplist"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eec25f46463fcdc5e02f388c2780b1b58e01be81a8378e62ec60931beccc3f6"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/epoch_broadcaster/src/server.rs
+++ b/epoch_broadcaster/src/server.rs
@@ -1,14 +1,22 @@
+use flatbuffers::FlatBufferBuilder;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
 
+use bytes::Bytes;
+use common::network::fast_network::FastNetwork;
 use proto::epoch_broadcaster::epoch_broadcaster_server::{
     EpochBroadcaster, EpochBroadcasterServer,
 };
 use proto::epoch_broadcaster::{SetEpochRequest, SetEpochResponse};
+use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server as TServer, Request, Response, Status as TStatus};
+
+use flatbuf::epoch_broadcaster_flatbuffers::epoch_broadcaster::*;
+
+type DynamicErr = Box<dyn std::error::Error + Sync + Send + 'static>;
 
 pub struct Server {
     epoch: AtomicUsize,
@@ -39,26 +47,156 @@ impl EpochBroadcaster for ProtoServer {
     }
 }
 
-pub fn new(bg_runtime: tokio::runtime::Handle) -> Arc<Server> {
-    Arc::new(Server {
-        epoch: AtomicUsize::new(0),
-        bg_runtime,
-    })
-}
+impl Server {
+    async fn read_epoch(
+        &self,
+        network: Arc<dyn FastNetwork>,
+        sender: SocketAddr,
+        request: ReadEpochRequest<'_>,
+    ) -> Result<(), DynamicErr> {
+        let mut fbb = FlatBufferBuilder::new();
+        let fbb_root = match request.request_id() {
+            None => ReadEpochResponse::create(
+                &mut fbb,
+                &ReadEpochResponseArgs {
+                    request_id: None,
+                    status: Status::InvalidRequestFormat,
+                    epoch: 0,
+                },
+            ),
+            Some(request_id) => {
+                let epoch = self.epoch.load(SeqCst);
+                let status = if epoch <= 0 {
+                    Status::EpochUnknown
+                } else {
+                    Status::Ok
+                };
+                let request_id = Some(Uuidu128::create(
+                    &mut fbb,
+                    &Uuidu128Args {
+                        lower: request_id.lower(),
+                        upper: request_id.upper(),
+                    },
+                ));
+                ReadEpochResponse::create(
+                    &mut fbb,
+                    &ReadEpochResponseArgs {
+                        request_id,
+                        status,
+                        epoch: epoch as u64,
+                    },
+                )
+            }
+        };
 
-pub fn start(server: Arc<Server>) {
-    let proto_server = ProtoServer {
-        server: server.clone(),
-    };
-    server.bg_runtime.spawn(async move {
-        // TODO(tamer): make this configurable.
-        let addr = SocketAddr::from_str("127.0.0.1:10010").unwrap();
-        if let Err(e) = TServer::builder()
-            .add_service(EpochBroadcasterServer::new(proto_server))
-            .serve(addr)
-            .await
-        {
-            println!("Unable to start proto server: {}", e);
+        fbb.finish(fbb_root, None);
+        self.send_response(network, sender, MessageType::ReadEpoch, fbb.finished_data())?;
+        Ok(())
+    }
+
+    async fn handle_message(
+        server: Arc<Self>,
+        fast_network: Arc<dyn FastNetwork>,
+        sender: SocketAddr,
+        msg: Bytes,
+    ) -> Result<(), DynamicErr> {
+        // TODO: gracefully handle malformed messages instead of unwrapping and crashing.
+        let msg = msg.to_vec();
+        let envelope = flatbuffers::root::<RequestEnvelope>(msg.as_slice())?;
+        match envelope.type_() {
+            MessageType::ReadEpoch => {
+                let req = flatbuffers::root::<ReadEpochRequest>(envelope.bytes().unwrap().bytes())?;
+                server.read_epoch(fast_network.clone(), sender, req).await?
+            }
+            _ => (), // TODO: return and log unknown message type error.
+        };
+        Ok(())
+    }
+
+    fn send_response(
+        &self,
+        fast_network: Arc<dyn FastNetwork>,
+        sender: SocketAddr,
+        msg_type: MessageType,
+        msg_payload: &[u8],
+    ) -> Result<(), std::io::Error> {
+        // TODO: many allocations and copies in this function.
+        let mut fbb = FlatBufferBuilder::new();
+        let bytes = fbb.create_vector(msg_payload);
+        let fb_root = ResponseEnvelope::create(
+            &mut fbb,
+            &ResponseEnvelopeArgs {
+                type_: msg_type,
+                bytes: Some(bytes),
+            },
+        );
+        fbb.finish(fb_root, None);
+        let response = Bytes::copy_from_slice(fbb.finished_data());
+        fast_network.send(sender, response)
+    }
+
+    async fn network_server_loop(
+        server: Arc<Self>,
+        fast_network: Arc<dyn FastNetwork>,
+        cancellation_token: CancellationToken,
+    ) {
+        let mut network_receiver = fast_network.listen_default();
+        loop {
+            let () = tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    return ()
+                }
+                maybe_message = network_receiver.recv() => {
+                    match maybe_message {
+                        None => {
+                            println!("fast network closed unexpectedly!");
+                            cancellation_token.cancel()
+                        }
+                        Some((sender, msg)) => {
+                            let server = server.clone();
+                            let fast_network = fast_network.clone();
+                            tokio::spawn(async move{
+                                let _ = Self::handle_message(server, fast_network, sender, msg).await;
+                                // TODO log any error here.
+                            });
+
+                        }
+                    }
+                }
+            };
         }
-    });
+    }
+
+    pub fn new(bg_runtime: tokio::runtime::Handle) -> Arc<Server> {
+        Arc::new(Server {
+            epoch: AtomicUsize::new(0),
+            bg_runtime,
+        })
+    }
+
+    pub fn start(
+        server: Arc<Server>,
+        fast_network: Arc<dyn FastNetwork>,
+        cancellation_token: CancellationToken,
+    ) {
+        let proto_server = ProtoServer {
+            server: server.clone(),
+        };
+        server.bg_runtime.spawn(async move {
+            // TODO(tamer): make this configurable.
+            let addr = SocketAddr::from_str("127.0.0.1:10010").unwrap();
+            if let Err(e) = TServer::builder()
+                .add_service(EpochBroadcasterServer::new(proto_server))
+                .serve(addr)
+                .await
+            {
+                println!("Unable to start proto server: {}", e);
+            }
+        });
+
+        tokio::spawn(async move {
+            let _ = Self::network_server_loop(server, fast_network, cancellation_token).await;
+            println!("Network server loop exited!")
+        });
+    }
 }

--- a/flatbuf/target/rangeserver/schema_generated.rs
+++ b/flatbuf/target/rangeserver/schema_generated.rs
@@ -21,10 +21,10 @@ pub mod range_server {
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_STATUS: i8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_STATUS: i8 = 10;
+pub const ENUM_MAX_STATUS: i8 = 11;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_STATUS: [Status; 11] = [
+pub const ENUM_VALUES_STATUS: [Status; 12] = [
   Status::Ok,
   Status::InvalidRequestFormat,
   Status::RangeDoesNotExist,
@@ -35,6 +35,7 @@ pub const ENUM_VALUES_STATUS: [Status; 11] = [
   Status::InternalError,
   Status::TransactionAborted,
   Status::UnknownTransaction,
+  Status::CacheIsFull,
   Status::PrefetchError,
 ];
 
@@ -53,10 +54,11 @@ impl Status {
   pub const InternalError: Self = Self(7);
   pub const TransactionAborted: Self = Self(8);
   pub const UnknownTransaction: Self = Self(9);
-  pub const PrefetchError: Self = Self(10);
+  pub const CacheIsFull: Self = Self(10);
+  pub const PrefetchError: Self = Self(11);
 
   pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 10;
+  pub const ENUM_MAX: i8 = 11;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::Ok,
     Self::InvalidRequestFormat,
@@ -68,6 +70,7 @@ impl Status {
     Self::InternalError,
     Self::TransactionAborted,
     Self::UnknownTransaction,
+    Self::CacheIsFull,
     Self::PrefetchError,
   ];
   /// Returns the variant's name or "" if unknown.
@@ -83,6 +86,7 @@ impl Status {
       Self::InternalError => Some("InternalError"),
       Self::TransactionAborted => Some("TransactionAborted"),
       Self::UnknownTransaction => Some("UnknownTransaction"),
+      Self::CacheIsFull => Some("CacheIsFull"),
       Self::PrefetchError => Some("PrefetchError"),
       _ => None,
     }

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use crate::transaction_info::TransactionInfo;
 use crate::warden_handler::WardenHandler;
 use crate::{
-    epoch_provider::EpochProvider, error::Error, for_testing::in_memory_wal::InMemoryWal,
-    range_manager::RangeManager, storage::Storage, cache::Cache, cache::memtabledb::MemTableDB, cache::CacheOptions,
+    cache::Cache, cache::CacheOptions, epoch_provider::EpochProvider, error::Error,
+    for_testing::in_memory_wal::InMemoryWal, range_manager::RangeManager, storage::Storage,
 };
 use flatbuf::rangeserver_flatbuffers::range_server::TransactionInfo as FlatbufTransactionInfo;
 use flatbuf::rangeserver_flatbuffers::range_server::*;
@@ -735,6 +735,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
+    use crate::cache::memtabledb::MemTableDB;
     use common::config::{RangeServerConfig, RegionConfig};
     use common::network::for_testing::udp_fast_network::UdpFastNetwork;
     use common::region::{Region, Zone};


### PR DESCRIPTION
Server-side implementation of the read-epoch RPC on the broadcaster.

This is mostly boiler plate using the fast network API and flatbuffer marshalling. The core logic is simply just reading the epoch value.