### PR TITLE
EpochPublisher sync epoch on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "derivative",
  "flatbuf",
  "flatbuffers",
  "tokio",
@@ -305,6 +306,17 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if",
  "num_cpus",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,3 +11,4 @@ bytes = "1"
 flatbuf = {path = "../flatbuf"}
 flatbuffers = "24.3.25"
 tokio = { version = "1", features = ["full"] }
+derivative = "2.2.0"

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,19 +1,47 @@
-use crate::region::Region;
+use crate::region::{Region, Zone};
 use core::time;
-use std::collections::HashMap;
+use derivative::Derivative;
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+};
+
+#[derive(Clone, Debug)]
+pub struct EpochConfig {
+    pub proto_server_addr: SocketAddr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct EpochPublisher {
+    pub name: String,
+    pub backend_addr: SocketAddr,
+    pub fast_network_addr: SocketAddr,
+}
+
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct EpochPublisherSet {
+    pub name: String,
+    pub zone: Zone,
+    #[derivative(Hash = "ignore")]
+    pub publishers: HashSet<EpochPublisher>,
+}
+
 #[derive(Clone, Debug)]
 pub struct RangeServerConfig {
     pub range_maintenance_duration: time::Duration,
-    pub proto_server_addr: String,
+    pub proto_server_addr: SocketAddr,
 }
 
 #[derive(Clone, Debug)]
 pub struct RegionConfig {
-    pub warden_address: String,
+    pub warden_address: SocketAddr,
+    pub epoch_publishers: HashSet<EpochPublisherSet>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Config {
     pub range_server: RangeServerConfig,
+    pub epoch: EpochConfig,
     pub regions: HashMap<Region, RegionConfig>,
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,17 @@
 use std::fs;
 
 fn main() {
+    let epoch_out_dir = "target/epoch";
+    fs::create_dir_all(epoch_out_dir).unwrap();
+    tonic_build::configure()
+        .build_server(true)
+        .out_dir(epoch_out_dir)
+        .compile(
+            &["src/epoch.proto"],
+            &["src"], // specify the root location to search proto dependencies
+        )
+        .unwrap();
+
     let epoch_publisher_out_dir = "target/epoch_publisher";
     fs::create_dir_all(epoch_publisher_out_dir).unwrap();
     tonic_build::configure()

--- a/proto/src/epoch.proto
+++ b/proto/src/epoch.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package epoch;
+
+service Epoch {
+    rpc ReadEpoch (ReadEpochRequest) returns (ReadEpochResponse);
+}
+
+message ReadEpochRequest {
+}
+
+message ReadEpochResponse {
+    uint64 epoch = 1;
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,3 +1,5 @@
+#[path = "../target/epoch/epoch.rs"]
+pub mod epoch;
 #[path = "../target/epoch_publisher/epoch_publisher.rs"]
 pub mod epoch_publisher;
 #[path = "../target/rangeserver/rangeserver.rs"]

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -1,11 +1,12 @@
 use std::{
+    collections::HashSet,
     net::{SocketAddr, UdpSocket},
     sync::Arc,
     time,
 };
 
 use common::{
-    config::{Config, RangeServerConfig, RegionConfig},
+    config::{Config, EpochConfig, RangeServerConfig, RegionConfig},
     host_info::HostInfo,
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},
     region::{Region, Zone},
@@ -61,14 +62,19 @@ fn get_config(warden_address: SocketAddr) -> Config {
         name: "test-region".into(),
     };
     let region_config = RegionConfig {
-        warden_address: warden_address.to_string(),
+        warden_address: warden_address,
+        epoch_publishers: HashSet::new(),
+    };
+    let epoch = EpochConfig {
+        proto_server_addr: "127.0.0.1:50052".parse().unwrap(),
     };
     let mut config = Config {
         range_server: RangeServerConfig {
             range_maintenance_duration: time::Duration::from_secs(1),
-            proto_server_addr: String::from("127.0.0.1:50051"),
+            proto_server_addr: "127.0.0.1:50051".parse().unwrap(),
         },
         regions: std::collections::HashMap::new(),
+        epoch,
     };
     config.regions.insert(region, region_config);
     config

--- a/rangeserver/src/range_manager.rs
+++ b/rangeserver/src/range_manager.rs
@@ -675,10 +675,11 @@ where
 #[cfg(test)]
 mod tests {
 
-    use common::config::RangeServerConfig;
+    use common::config::{EpochConfig, RangeServerConfig};
     use common::util;
     use core::time;
     use flatbuffers::FlatBufferBuilder;
+    use std::net::SocketAddr;
     use uuid::Uuid;
 
     use super::*;
@@ -818,12 +819,17 @@ mod tests {
             keyspace_id: storage_context.keyspace_id,
             range_id: storage_context.range_id,
         };
+        let epoch_config = EpochConfig {
+            // Not used in these tests.
+            proto_server_addr: "127.0.0.1:50052".parse().unwrap(),
+        };
         let config = Config {
             range_server: RangeServerConfig {
                 range_maintenance_duration: time::Duration::from_secs(1),
-                proto_server_addr: String::from("127.0.0.1:50051"),
+                proto_server_addr: "127.0.0.1:50051".parse().unwrap(),
             },
             regions: std::collections::HashMap::new(),
+            epoch: epoch_config,
         };
         let rm = Arc::new(RM {
             range_id,

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -697,12 +697,7 @@ where
         });
 
         // Pull the gRPC server address and define the service
-        let addr = server
-            .config
-            .range_server
-            .proto_server_addr
-            .parse()
-            .unwrap();
+        let addr = server.config.range_server.proto_server_addr;
 
         let prefetch = ProtoServer {
             parent_server: server.clone(),
@@ -736,10 +731,11 @@ where
 #[cfg(test)]
 pub mod tests {
     use crate::cache::memtabledb::MemTableDB;
-    use common::config::{RangeServerConfig, RegionConfig};
+    use common::config::{EpochConfig, RangeServerConfig, RegionConfig};
     use common::network::for_testing::udp_fast_network::UdpFastNetwork;
     use common::region::{Region, Zone};
     use core::time;
+    use std::collections::HashSet;
     use std::net::UdpSocket;
 
     use super::*;
@@ -781,14 +777,20 @@ pub mod tests {
             name: "a".into(),
         };
         let region_config = RegionConfig {
-            warden_address: warden_address.to_string(),
+            warden_address: warden_address,
+            epoch_publishers: HashSet::new(),
+        };
+        let epoch_config = EpochConfig {
+            // Not used in these tests.
+            proto_server_addr: "127.0.0.1:50052".parse().unwrap(),
         };
         let mut config = Config {
             range_server: RangeServerConfig {
                 range_maintenance_duration: time::Duration::from_secs(1),
-                proto_server_addr: String::from("127.0.0.1:50051"),
+                proto_server_addr: "127.0.0.1:50051".parse().unwrap(),
             },
             regions: std::collections::HashMap::new(),
+            epoch: epoch_config,
         };
         config.regions.insert(region, region_config);
         let identity: String = "test_server".into();


### PR DESCRIPTION
The main goal of this PR is to have the EpochPublisher sync its epoch from the Epoch service on startup, before serving any requests.

To achieve this, I add a proto definition of the Epoch service, and some config changes as well.