### PR TITLE
Use EpochReader in RangeServer as the EpochSupplier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,8 @@ dependencies = [
  "bytes",
  "chrono",
  "common",
+ "epoch_publisher",
+ "epoch_reader",
  "flatbuf",
  "flatbuffers",
  "machnet",

--- a/epoch_reader/src/reader.rs
+++ b/epoch_reader/src/reader.rs
@@ -46,6 +46,7 @@ impl EpochReader {
     }
 
     pub async fn read_epoch(&self) -> Result<u64, Error> {
+        // TODO(tamer): add timeout and retries.
         // Fire off a request to read the epoch from each publisher in the set in parallel.
         let mut join_set = JoinSet::new();
         for c in &self.clients {

--- a/rangeserver/Cargo.toml
+++ b/rangeserver/Cargo.toml
@@ -13,6 +13,8 @@ scylla = "0.3.1"
 bytes = "1"
 flatbuf = {path = "../flatbuf"}
 proto = {path = "../proto"}
+epoch_publisher = {path = "../epoch_publisher"}
+epoch_reader = {path = "../epoch_reader"}
 chrono = "0.4.34"
 flatbuffers = "24.3.25"
 thiserror = "1.0.57"

--- a/rangeserver/src/epoch_supplier.rs
+++ b/rangeserver/src/epoch_supplier.rs
@@ -1,10 +1,5 @@
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Unknown")]
-    Unknown,
-}
+pub mod reader;
+use epoch_publisher::error::Error;
 
 pub trait EpochSupplier: Send + Sync + 'static {
     // Values returned must satisfy the Global Epoch Invariant:
@@ -17,5 +12,6 @@ pub trait EpochSupplier: Send + Sync + 'static {
     fn wait_until_epoch(
         &self,
         epoch: u64,
+        timeout: chrono::Duration,
     ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 }

--- a/rangeserver/src/epoch_supplier/reader.rs
+++ b/rangeserver/src/epoch_supplier/reader.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use super::*;
+use common::{config::EpochPublisherSet, network::fast_network::FastNetwork};
+use epoch_publisher::error::Error;
+use epoch_reader::reader::EpochReader;
+use tokio::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+pub struct Reader {
+    epoch_reader: EpochReader,
+}
+
+impl Reader {
+    pub fn new(
+        fast_network: Arc<dyn FastNetwork>,
+        runtime: tokio::runtime::Handle,
+        publisher_set: EpochPublisherSet,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        Reader {
+            epoch_reader: EpochReader::new(
+                fast_network,
+                runtime,
+                publisher_set,
+                cancellation_token,
+            ),
+        }
+    }
+}
+
+impl EpochSupplier for Reader {
+    async fn read_epoch(&self) -> Result<u64, Error> {
+        self.epoch_reader.read_epoch().await
+    }
+
+    async fn wait_until_epoch(
+        &self,
+        target_epoch: u64,
+        timeout: chrono::Duration,
+    ) -> Result<(), Error> {
+        let start_time = chrono::Local::now();
+        loop {
+            let current_epoch = self.read_epoch().await?;
+            if current_epoch >= target_epoch {
+                return Ok(());
+            }
+            let now = chrono::Local::now();
+            if (now - start_time) > timeout {
+                return Err(Error::Timeout);
+            }
+            // TODO(tamer): make this configurable.
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+}

--- a/rangeserver/src/error.rs
+++ b/rangeserver/src/error.rs
@@ -1,8 +1,8 @@
 use crate::{
-    cache::Error as CacheError, epoch_supplier::Error as EpochSupplierError,
-    storage::Error as StorageError, transaction_abort_reason::TransactionAbortReason,
-    wal::Error as WalError,
+    cache::Error as CacheError, storage::Error as StorageError,
+    transaction_abort_reason::TransactionAbortReason, wal::Error as WalError,
 };
+use epoch_publisher::error::Error as EpochSupplierError;
 
 use flatbuf::rangeserver_flatbuffers::range_server::Status;
 
@@ -47,10 +47,8 @@ impl Error {
         }
     }
 
-    pub fn from_epoch_provider_error(e: EpochSupplierError) -> Self {
-        match e {
-            EpochSupplierError::Unknown => Self::InternalError(Arc::new(e)),
-        }
+    pub fn from_epoch_supplier_error(e: EpochSupplierError) -> Self {
+        Self::InternalError(Arc::new(e))
     }
 
     pub fn to_flatbuf_status(&self) -> Status {

--- a/rangeserver/src/for_testing/epoch_supplier.rs
+++ b/rangeserver/src/for_testing/epoch_supplier.rs
@@ -1,4 +1,5 @@
 use crate::epoch_supplier::EpochSupplier as Trait;
+use epoch_publisher::error::Error;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::sync::RwLock;
@@ -60,12 +61,12 @@ impl EpochSupplier {
 }
 
 impl Trait for EpochSupplier {
-    async fn read_epoch(&self) -> Result<u64, crate::epoch_supplier::Error> {
+    async fn read_epoch(&self) -> Result<u64, Error> {
         let state = self.state.read().unwrap();
         Ok(state.epoch)
     }
 
-    async fn wait_until_epoch(&self, epoch: u64) -> Result<(), crate::epoch_supplier::Error> {
+    async fn wait_until_epoch(&self, epoch: u64, _timeout: chrono::Duration) -> Result<(), Error> {
         let (s, r) = oneshot::channel();
         {
             let mut state = self.state.write().unwrap();

--- a/rangeserver/src/range_manager.rs
+++ b/rangeserver/src/range_manager.rs
@@ -214,7 +214,7 @@ where
             .epoch_supplier
             .read_epoch()
             .await
-            .map_err(Error::from_epoch_provider_error)?;
+            .map_err(Error::from_epoch_supplier_error)?;
         let range_info = self
             .storage
             .take_ownership_and_load_range(self.range_id)
@@ -224,9 +224,9 @@ where
         // of a range cannot move backward even across range load/unloads, so to maintain that guarantee
         // we just wait for the epoch to advance once.
         self.epoch_supplier
-            .wait_until_epoch(epoch + 1)
+            .wait_until_epoch(epoch + 1, chrono::Duration::seconds(10))
             .await
-            .map_err(Error::from_epoch_provider_error)?;
+            .map_err(Error::from_epoch_supplier_error)?;
         // Get a new epoch lease.
         let highest_known_epoch = epoch + 1;
         let new_epoch_lease_lower_bound =
@@ -268,7 +268,7 @@ where
             let epoch = epoch_supplier
                 .read_epoch()
                 .await
-                .map_err(Error::from_epoch_provider_error)?;
+                .map_err(Error::from_epoch_supplier_error)?;
             let highest_known_epoch = epoch + 1;
             if let State::Loaded(state) = state.read().await.deref() {
                 old_lease = state.range_info.epoch_lease;

--- a/warden/src/persistence.rs
+++ b/warden/src/persistence.rs
@@ -12,7 +12,6 @@ pub struct RangeInfo {
     pub key_range: KeyRange,
 }
 
-
 #[derive(Debug)]
 pub struct RangeAssignment {
     pub range: RangeInfo,


### PR DESCRIPTION
An EpochSupplier implementation that uses the EpochReader to get the real epoch from an epoch publisher set.