### PR TITLE
Use dyn EpochSupplier in rangeserver

### DIFF
--- a/rangeclient/tests/integration_tests.rs
+++ b/rangeclient/tests/integration_tests.rs
@@ -99,7 +99,7 @@ async fn setup_server(
         let config = get_config(warden_address);
         let host_info = get_server_host_info(server_address);
         let bg_runtime = Builder::new_multi_thread().enable_all().build().unwrap();
-        let server = Server::<_, _, MemTableDB>::new(
+        let server = Server::<_, MemTableDB>::new(
             config,
             host_info,
             storage,

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
         let host_info = get_host_info();
         // TODO: set number of threads and pin to cores.
         let bg_runtime = Builder::new_multi_thread().enable_all().build().unwrap();
-        let server = Server::<_, _, MemTableDB>::new(
+        let server = Server::<_, MemTableDB>::new(
             config,
             host_info,
             storage,


### PR DESCRIPTION
This makes it easier to dynamically choose the implementation of the EpochSupplier in range (e.g. based on a config)