### PR TITLE
kubernetes: Deploy all chardonnay components

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -73,3 +73,5 @@ jobs:
         target: ${{ matrix.target }}
         tags: ${{ matrix.tags }}
         push: false
+
+  # TODO: Add an action to test deploying Chardonnay on a minikube cluster

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "proto",
  "serde",
  "tokio",
+ "tracing",
  "uuid 0.8.2",
 ]
 
@@ -534,6 +535,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tracing",
  "uuid 0.8.2",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ WORKDIR /chardonnay_build
 # Copy the entire project
 COPY . .
 
-# Install dependencies
-
 # Build the project
 RUN cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -88,13 +88,16 @@ docker build -t "$EPOCH_IMG:$TAG" --target epoch .
 Prerequisites:
 - Minikube installation
 
+:warning: Currently, the Kubernetes deployment in anticipation of the universe manager.
+
+
 1. Start minikube:
 
    ```sh
    minikube start
    ```
 
-1. Load chardonnay docker images on minikube:
+2. Load chardonnay docker images on minikube:
 
    ```sh
    minikube image load --overwrite "$RANGESERVER_IMG:$TAG"
@@ -112,7 +115,7 @@ Prerequisites:
    minikube image rm "$EPOCH_IMG:$TAG"
    ```
 
-1. Apply chardonnay manifests for deploying on Kubernetes:
+3. Apply chardonnay manifests for deploying on Kubernetes:
 
    ```sh
    kubectl apply \
@@ -128,7 +131,7 @@ Prerequisites:
    dependencies are not available yet, instead of simply retrying. This means
    you may need to wait for some minutes for the deployment to stabilize.
 
-1. Exec into the cassandra container and create the necessary keyspace and
+4. Exec into the cassandra container and create the necessary keyspace and
    schema:
 
    ```sh
@@ -141,7 +144,7 @@ Prerequisites:
    # Copy paste the commands from schema.cql
    ```
 
-1. Confirm that everything becomes ready:
+5. Confirm that everything becomes ready:
 
    ```sh
    kubectl get pods -n chardonnay

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,3 +14,4 @@ flatbuffers = "24.3.25"
 tokio = { version = "1", features = ["full"] }
 derivative = "2.2.0"
 serde = { version = "1.0.210", features = ["derive"] }
+tracing = "0.1.40"

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,8 +1,9 @@
 use crate::region::{Region, Zone};
-use core::{panic, time};
+use core::time;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::vec;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -23,24 +24,18 @@ impl HostPort {
         format!("{}:{}", self.host, self.port)
     }
 
-    pub fn to_socket_addr(&self) -> std::net::SocketAddr {
-        // Check if host is an IP address.
-        if !self.host.parse::<std::net::IpAddr>().is_ok() {
-            let resolved_addr = (self.host.as_str(), self.port)
-                .to_socket_addrs()
-                .unwrap()
-                .next()
-                .unwrap();
-            return resolved_addr;
-        }
-        format!("{}:{}", self.host, self.port).parse().unwrap()
-    }
-
     pub fn from_socket_addr(addr: std::net::SocketAddr) -> Self {
         HostPort {
             host: addr.ip().to_string(),
             port: addr.port(),
         }
+    }
+}
+
+impl ToSocketAddrs for HostPort {
+    type Iter = vec::IntoIter<std::net::SocketAddr>;
+    fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
+        (self.host.as_str(), self.port).to_socket_addrs()
     }
 }
 

--- a/common/src/network/for_testing/udp_fast_network.rs
+++ b/common/src/network/for_testing/udp_fast_network.rs
@@ -7,6 +7,7 @@ use std::{
 
 use bytes::Bytes;
 use tokio::sync::mpsc;
+use tracing::trace;
 
 enum DefaultHandler {
     NotRegistered,
@@ -31,7 +32,9 @@ impl UdpFastNetwork {
 
 impl Trait for UdpFastNetwork {
     fn send(&self, to: SocketAddr, payload: Bytes) -> Result<(), std::io::Error> {
+        trace!("Sending to: {:?}", to);
         self.socket.send_to(payload.to_vec().as_slice(), to)?;
+        trace!("Send finished");
         Ok(())
     }
 

--- a/epoch/src/main.rs
+++ b/epoch/src/main.rs
@@ -11,7 +11,7 @@ async fn main() {
     let config: Config =
         serde_json::from_str(&std::fs::read_to_string("config.json").unwrap()).unwrap();
     let storage = epoch::storage::cassandra::Cassandra::new(
-        "127.0.0.1:9042".to_string(),
+        config.cassandra.cql_addr.to_string(),
         "GLOBAL".to_string(),
     )
     .await;

--- a/epoch/src/server.rs
+++ b/epoch/src/server.rs
@@ -5,6 +5,7 @@ use crate::storage::Storage;
 use common::config::Config;
 use proto::epoch::epoch_server::{Epoch, EpochServer};
 use proto::epoch::{ReadEpochRequest, ReadEpochResponse};
+use std::net::ToSocketAddrs;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server as TServer, Request, Response, Status as TStatus};
@@ -84,7 +85,14 @@ where
         };
         Server::<S>::start_update_loop(server.clone(), cancellation_token);
         // TODO(tamer): make this configurable.
-        let addr = server.config.epoch.proto_server_addr.to_socket_addr();
+        let addr = server
+            .config
+            .epoch
+            .proto_server_addr
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
         if let Err(e) = TServer::builder()
             .add_service(EpochServer::new(proto_server))
             .serve(addr)

--- a/epoch/src/server.rs
+++ b/epoch/src/server.rs
@@ -84,7 +84,7 @@ where
         };
         Server::<S>::start_update_loop(server.clone(), cancellation_token);
         // TODO(tamer): make this configurable.
-        let addr = server.config.epoch.proto_server_addr;
+        let addr = server.config.epoch.proto_server_addr.to_socket_addr();
         if let Err(e) = TServer::builder()
             .add_service(EpochServer::new(proto_server))
             .serve(addr)

--- a/epoch_publisher/src/main.rs
+++ b/epoch_publisher/src/main.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
+use std::{net::ToSocketAddrs, sync::Arc};
 
-use common::config::Config;
+use common::{config::Config, network::fast_network};
 use std::net::UdpSocket;
 use tracing_subscriber;
 
@@ -41,8 +41,14 @@ fn main() {
         .find(|&x| x.name == publisher_name)
         .unwrap();
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+    let fast_network_addr = publisher_config
+        .fast_network_addr
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
     let fast_network = Arc::new(UdpFastNetwork::new(
-        UdpSocket::bind(publisher_config.fast_network_addr.to_socket_addr()).unwrap(),
+        UdpSocket::bind(fast_network_addr).unwrap(),
     ));
     let fast_network_clone = fast_network.clone();
     runtime.spawn(async move {

--- a/epoch_publisher/src/main.rs
+++ b/epoch_publisher/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
         .unwrap();
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
     let fast_network = Arc::new(UdpFastNetwork::new(
-        UdpSocket::bind(publisher_config.fast_network_addr).unwrap(),
+        UdpSocket::bind(publisher_config.fast_network_addr.to_socket_addr()).unwrap(),
     ));
     let fast_network_clone = fast_network.clone();
     runtime.spawn(async move {

--- a/epoch_publisher/src/server.rs
+++ b/epoch_publisher/src/server.rs
@@ -245,7 +245,7 @@ impl Server {
             // TODO(tamer): make this configurable.
             if let Err(e) = TServer::builder()
                 .add_service(EpochPublisherServer::new(proto_server))
-                .serve(server_clone.publisher_config.backend_addr.clone())
+                .serve(server_clone.publisher_config.backend_addr.to_socket_addr())
                 .await
             {
                 panic!("Unable to start proto server: {}", e);

--- a/epoch_publisher/src/server.rs
+++ b/epoch_publisher/src/server.rs
@@ -3,6 +3,7 @@ use common::config::EpochPublisher as EpochPublisherConfig;
 use flatbuffers::FlatBufferBuilder;
 use proto::epoch::epoch_client::EpochClient;
 use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
@@ -241,11 +242,18 @@ impl Server {
             server: server.clone(),
         };
         let server_clone = server.clone();
+        let addr = server
+            .publisher_config
+            .backend_addr
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
         server.bg_runtime.spawn(async move {
             // TODO(tamer): make this configurable.
             if let Err(e) = TServer::builder()
                 .add_service(EpochPublisherServer::new(proto_server))
-                .serve(server_clone.publisher_config.backend_addr.to_socket_addr())
+                .serve(addr)
                 .await
             {
                 panic!("Unable to start proto server: {}", e);

--- a/epoch_publisher/tests/integration_tests.rs
+++ b/epoch_publisher/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use common::{
     config::{
-        CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig,
+        CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig, HostPort,
         RangeServerConfig, RegionConfig,
     },
     host_info::HostInfo,
@@ -44,13 +44,13 @@ fn get_config(epoch_address: SocketAddr) -> Config {
     };
     let epoch_config = EpochConfig {
         // Not used in these tests.
-        proto_server_addr: epoch_address,
+        proto_server_addr: HostPort::from_socket_addr(epoch_address),
     };
     let mut config = Config {
         range_server: RangeServerConfig {
             range_maintenance_duration: time::Duration::from_secs(1),
-            proto_server_port: 50054,
-            fast_network_port: 50055,
+            proto_server_addr: HostPort::from_str("127.0.0.1:50054").unwrap(),
+            fast_network_addr: HostPort::from_str("127.0.0.1:50055").unwrap(),
         },
         cassandra: CassandraConfig {
             cql_addr: "127.0.0.1:9042".parse().unwrap(),
@@ -63,11 +63,11 @@ fn get_config(epoch_address: SocketAddr) -> Config {
 }
 
 fn get_publisher_config(fast_network_addr: SocketAddr) -> EpochPublisherConfig {
-    let backend_addr = SocketAddr::from_str("127.0.0.1:10010").unwrap();
+    let backend_addr = HostPort::from_str("127.0.0.1:10010").unwrap();
     EpochPublisherConfig {
         name: "ep1".to_string(),
         backend_addr,
-        fast_network_addr,
+        fast_network_addr: HostPort::from_socket_addr(fast_network_addr),
     }
 }
 

--- a/epoch_reader/Cargo.toml
+++ b/epoch_reader/Cargo.toml
@@ -21,6 +21,7 @@ tonic = "0.11.0"
 tokio-util = "0.7.10"
 tokio-stream = {version = "0.1.15", features = ["net"]}
 prost = "0.12"
+tracing = "0.1.40"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/epoch_reader/src/reader.rs
+++ b/epoch_reader/src/reader.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use common::{config::EpochPublisherSet, host_info::HostInfo, network::fast_network::FastNetwork};
 use epoch_publisher::{client::EpochPublisherClient, error::Error};
+use std::net::ToSocketAddrs;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -28,7 +29,12 @@ impl EpochReader {
             .map(|publisher| {
                 let host_info = HostInfo {
                     identity: publisher.name.clone(),
-                    address: publisher.fast_network_addr.to_socket_addr(),
+                    address: publisher
+                        .fast_network_addr
+                        .to_socket_addrs()
+                        .unwrap()
+                        .next()
+                        .unwrap(),
                     zone: publisher_set.zone.clone(),
                     warden_connection_epoch: 0,
                 };

--- a/kubernetes/epoch_publisher.yaml
+++ b/kubernetes/epoch_publisher.yaml
@@ -1,70 +1,69 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: chardonnay-rangeserver
+  name: chardonnay-epoch-publisher
   namespace: chardonnay
 spec:
-  serviceName: "chardonnay-rangeserver"
+  serviceName: "chardonnay-epoch-publisher"
   replicas: 1
   selector:
     matchLabels:
-      app: chardonnay-rangeserver
+      app: chardonnay-epoch-publisher
   template:
     metadata:
       labels:
-        app: chardonnay-rangeserver
+        app: chardonnay-epoch-publisher
     spec:
       containers:
-      - name: rangeserver
-        image: chardonnay-rangeserver:latest
+      - name: epoch-publisher
+        image: chardonnay-epoch-publisher:latest
         imagePullPolicy: IfNotPresent
-        workingDir: /etc/chardonnay
-        command: ["/bin/sh", "-c"]
-        args: ["cat /etc/chardonnay/config.json && rangeserver"]
-        env:
-          - name: RUST_BACKTRACE
-            value: "1"
-          - name: RUST_LOG
-            value: "info"
         ports:
-        - containerPort: 50054
-          name: proto-server
+        - containerPort: 50051
+          name: backend
           protocol: TCP
-        - containerPort: 50055
+        - containerPort: 50052
           name: fast-network
           protocol: UDP
+        env:
+        - name: RUST_LOG
+          value: "info"
+        workingDir: /etc/chardonnay
+        command: ["/bin/sh", "-c"]
+        args: ["cat /etc/chardonnay/config.json && epoch_publisher"]
         volumeMounts:
         - name: config
           mountPath: /etc/chardonnay
       volumes:
       - name: config
         configMap:
-          name: chardonnay-rangeserver-config
+          name: chardonnay-epoch-publisher-config
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: chardonnay-rangeserver
+  name: chardonnay-epoch-publisher
   namespace: chardonnay
 spec:
   selector:
-    app: chardonnay-rangeserver
+    app: chardonnay-epoch-publisher
   clusterIP: None
   ports:
-    - protocol: TCP
-      port: 50054
-      targetPort: 50054
-      name: proto-server
-    - protocol: UDP
-      port: 50055
-      targetPort: 50055
-      name: fast-network
+    - name: backend
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+    - name: fast-network
+      protocol: UDP
+      port: 50052
+      targetPort: 50052
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: chardonnay-rangeserver-config
+  name: chardonnay-epoch-publisher-config
   namespace: chardonnay
 data:
   config.json: |
@@ -93,8 +92,8 @@ data:
                         "publishers": [
                             {
                                 "name": "ep1",
-                                "backend_addr": "chardonnay-epoch-publisher:50051",
-                                "fast_network_addr": "chardonnay-epoch-publisher:50052"
+                                "backend_addr": "0.0.0.0:50051",
+                                "fast_network_addr": "0.0.0.0:50052"
                             }
                         ]
                     }

--- a/kubernetes/epoch_service.yaml
+++ b/kubernetes/epoch_service.yaml
@@ -1,36 +1,90 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: chardonnay-epoch-service
+  name: chardonnay-epoch
   namespace: chardonnay
 spec:
-  serviceName: "chardonnay-epoch-service"
+  serviceName: "chardonnay-epoch"
   replicas: 1
   selector:
     matchLabels:
-      app: chardonnay-epoch-service
+      app: chardonnay-epoch
   template:
     metadata:
       labels:
-        app: chardonnay-epoch-service
+        app: chardonnay-epoch
     spec:
       containers:
       - name: epoch
-        image: chardonnay-epoch-service:latest
+        image: chardonnay-epoch:latest
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 8080
+        - containerPort: 50050
+        workingDir: /etc/chardonnay
+        command: ["/bin/sh", "-c"]
+        args: ["cat /etc/chardonnay/config.json && epoch"]
+        volumeMounts:
+        - name: config
+          mountPath: /etc/chardonnay
+      volumes:
+      - name: config
+        configMap:
+          name: chardonnay-epoch-config
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: chardonnay-epoch-service
+  name: chardonnay-epoch
   namespace: chardonnay
 spec:
   selector:
-    app: chardonnay-epoch-service
+    app: chardonnay-epoch
   # TODO: Expose epoch service ports
   clusterIP: None
   ports:
     - protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: 50050
+      targetPort: 50050
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chardonnay-epoch-config
+  namespace: chardonnay
+data:
+  config.json: |
+    {
+        "range_server": {
+            "range_maintenance_duration": {
+                "secs": 1,
+                "nanos": 0
+            },
+            "proto_server_addr": "0.0.0.0:50054",
+            "fast_network_addr": "0.0.0.0:50055"
+        },
+        "epoch": {
+            "proto_server_addr": "0.0.0.0:50050"
+        },
+        "cassandra": {
+            "cql_addr": "cassandra:9042"
+        },
+        "regions": {
+            "test-region": {
+                "warden_address": "chardonnay-warden:50053",
+                "epoch_publishers": [
+                    {
+                        "name": "ps1",
+                        "zone": "test-region/a",
+                        "publishers": [
+                            {
+                                "name": "ep1",
+                                "backend_addr": "chardonnay-epoch-publisher:50051",
+                                "fast_network_addr": "chardonnay-epoch-publisher:50052"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }

--- a/kubernetes/warden.yaml
+++ b/kubernetes/warden.yaml
@@ -17,8 +17,20 @@ spec:
       containers:
       - name: warden
         image: chardonnay-warden:latest
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 10010
+        - containerPort: 50053
+        workingDir: /etc/chardonnay
+        command: ["/bin/sh", "-c"]
+        args: ["cat /etc/chardonnay/config.json && warden"]
+        volumeMounts:
+        - name: config
+          mountPath: /etc/chardonnay
+      volumes:
+      - name: config
+        configMap:
+          name: chardonnay-warden-config
+
 ---
 apiVersion: v1
 kind: Service
@@ -32,5 +44,48 @@ spec:
   clusterIP: None
   ports:
     - protocol: TCP
-      port: 10010
-      targetPort: 10010
+      port: 50053
+      targetPort: 50053
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chardonnay-warden-config
+  namespace: chardonnay
+data:
+  config.json: |
+    {
+        "range_server": {
+            "range_maintenance_duration": {
+                "secs": 1,
+                "nanos": 0
+            },
+            "proto_server_addr": "0.0.0.0:50054",
+            "fast_network_addr": "0.0.0.0:50055"
+        },
+        "epoch": {
+            "proto_server_addr": "chardonnay-epoch:50050"
+        },
+        "cassandra": {
+            "cql_addr": "cassandra:9042"
+        },
+        "regions": {
+            "test-region": {
+                "warden_address": "0.0.0.0:50053",
+                "epoch_publishers": [
+                    {
+                        "name": "ps1",
+                        "zone": "test-region/a",
+                        "publishers": [
+                            {
+                                "name": "ep1",
+                                "backend_addr": "chardonnay-epoch-publisher:50051",
+                                "fast_network_addr": "chardonnay-epoch-publisher:50052"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }

--- a/rangeserver/src/config.json
+++ b/rangeserver/src/config.json
@@ -4,8 +4,8 @@
             "secs": 1,
             "nanos": 0
         },
-        "proto_server_port": 50054,
-        "fast_network_port": 50055
+        "proto_server_addr": "127.0.0.1:50054",
+        "fast_network_addr": "127.0.0.1:50055"
     },
     "epoch": {
         "proto_server_addr": "127.0.0.1:50050"

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -22,11 +22,7 @@ fn main() {
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
     let runtime_handle = runtime.handle().clone();
     let fast_network = Arc::new(UdpFastNetwork::new(
-        UdpSocket::bind(format!(
-            "127.0.0.1:{}",
-            config.range_server.fast_network_port
-        ))
-        .unwrap(),
+        UdpSocket::bind(config.range_server.fast_network_addr.to_socket_addr()).unwrap(),
     ));
     let fast_network_clone = fast_network.clone();
     runtime.spawn(async move {
@@ -44,12 +40,10 @@ fn main() {
             .iter()
             .find(|&s| s.zone == host_info.zone)
             .unwrap();
-        let proto_server_listener = TcpListener::bind(format!(
-            "127.0.0.1:{}",
-            config.range_server.proto_server_port
-        ))
-        .await
-        .unwrap();
+        let proto_server_listener =
+            TcpListener::bind(config.range_server.proto_server_addr.to_socket_addr())
+                .await
+                .unwrap();
         info!("Connecting to Cassandra at {}", config.cassandra.cql_addr);
         let storage = Arc::new(Cassandra::new(config.cassandra.cql_addr.to_string()).await);
         // TODO: set number of threads and pin to cores.

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -1,4 +1,7 @@
-use std::{net::UdpSocket, sync::Arc};
+use std::{
+    net::{ToSocketAddrs, UdpSocket},
+    sync::Arc,
+};
 use tracing_subscriber;
 
 use common::{
@@ -21,8 +24,15 @@ fn main() {
 
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
     let runtime_handle = runtime.handle().clone();
+    let fast_network_addr = config
+        .range_server
+        .fast_network_addr
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
     let fast_network = Arc::new(UdpFastNetwork::new(
-        UdpSocket::bind(config.range_server.fast_network_addr.to_socket_addr()).unwrap(),
+        UdpSocket::bind(fast_network_addr).unwrap(),
     ));
     let fast_network_clone = fast_network.clone();
     runtime.spawn(async move {
@@ -40,10 +50,14 @@ fn main() {
             .iter()
             .find(|&s| s.zone == host_info.zone)
             .unwrap();
-        let proto_server_listener =
-            TcpListener::bind(config.range_server.proto_server_addr.to_socket_addr())
-                .await
-                .unwrap();
+        let proto_server_addr = config
+            .range_server
+            .proto_server_addr
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let proto_server_listener = TcpListener::bind(proto_server_addr).await.unwrap();
         info!("Connecting to Cassandra at {}", config.cassandra.cql_addr);
         let storage = Arc::new(Cassandra::new(config.cassandra.cql_addr.to_string()).await);
         // TODO: set number of threads and pin to cores.

--- a/rangeserver/src/range_manager/impl.rs
+++ b/rangeserver/src/range_manager/impl.rs
@@ -572,6 +572,7 @@ mod tests {
     use common::util;
     use core::time;
     use flatbuffers::FlatBufferBuilder;
+    use std::str::FromStr;
     use uuid::Uuid;
 
     use super::*;
@@ -716,8 +717,8 @@ mod tests {
         let config = Config {
             range_server: RangeServerConfig {
                 range_maintenance_duration: time::Duration::from_secs(1),
-                proto_server_port: 50054,
-                fast_network_port: 50055,
+                proto_server_addr: HostPort::from_str("127.0.0.1:50054").unwrap(),
+                fast_network_addr: HostPort::from_str("127.0.0.1:50055").unwrap(),
             },
             cassandra: CassandraConfig {
                 cql_addr: HostPort {

--- a/rangeserver/src/warden_handler.rs
+++ b/rangeserver/src/warden_handler.rs
@@ -13,6 +13,7 @@ use tokio::sync::oneshot;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tonic::Request;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::epoch_supplier::EpochSupplier;


### PR DESCRIPTION
This commit adds support for deploying all Chardonnay components on a K8s cluster. It's been tested on minikube.

We make the following small changes to support this:
- We change the config for the rangeserver to also specify the listen address, not just the port. Before this, the rangeserver always bind a localhost UDP port, breaking both listening and sending (i.e., to the epoch publisher) when running in a non-localhost environment.
- In the config, the address fields for various components are interpreted differently depending on what component is running. For example, when warden is running, warden_address is the listen address. When other components are running, warden_address is the address where they connect with the warden. Thus, we replicate the ConfigMap for each component and change the addresses accordingly. Hopefully we simplify this in the future.