### PR TITLE
Transaction State table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,8 +1701,39 @@ dependencies = [
  "lz4_flex",
  "rand 0.8.5",
  "rand_pcg",
- "scylla-cql",
+ "scylla-cql 0.2.2",
  "scylla-macros 0.5.2",
+ "smallvec",
+ "snap",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "scylla"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8139623d3fb0c8205b15e84fa587f3aa0ba61f876c19a9157b688f7c1763a7c5"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "dashmap 5.5.3",
+ "futures",
+ "hashbrown 0.14.5",
+ "histogram",
+ "itertools 0.13.0",
+ "lazy_static",
+ "lz4_flex",
+ "rand 0.8.5",
+ "rand_pcg",
+ "scylla-cql 0.3.0",
+ "scylla-macros 0.6.0",
  "smallvec",
  "snap",
  "socket2",
@@ -1722,6 +1762,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla-cql"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7020bcd1f6fdbeaed356cd426bf294b2071bd7120d48d2e8e319295e2acdcd"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "lz4_flex",
+ "scylla-macros 0.6.0",
+ "snap",
+ "thiserror",
+ "tokio",
+ "uuid 1.10.0",
+]
+
+[[package]]
 name = "scylla-macros"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1793,18 @@ name = "scylla-macros"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d8b68f5c1cd0b233234f7fb69f5729c4ca6029b7de280da350a1582d45273e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3859b6938663fc5062e3b26f3611649c9bd26fb252e85f6fdfa581e0d2ce74b6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1944,18 +2013,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2200,6 +2269,16 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "tx_state_store"
+version = "0.1.0"
+dependencies = [
+ "scylla 0.14.0",
+ "thiserror",
+ "tokio",
+ "uuid 1.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = [ "common", "epoch", "epoch_publisher", "epoch_reader", "flatbuf", "proto", "rangeclient", "rangeserver", "warden"]
+members = [ "common", "epoch", "epoch_publisher", "epoch_reader", "flatbuf", "proto", "rangeclient", "rangeserver", "tx_state_store", "warden"]

--- a/schema/cassandra/chardonnay/schema.cql
+++ b/schema/cassandra/chardonnay/schema.cql
@@ -59,3 +59,13 @@ CREATE TABLE wal (
   AND COMPACTION = {
      'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
+
+CREATE TABLE transactions (
+    transaction_id    uuid,
+    status            text,
+    epoch             bigint,
+    commit_info       blob,
+    PRIMARY KEY  (transaction_id)
+) WITH COMPACTION = {
+     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/tx_state_store/Cargo.toml
+++ b/tx_state_store/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tx_state_store"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+scylla = "0.14.0"
+thiserror = "1.0.64"
+tokio = "1.40.0"
+uuid = "1.10.0"

--- a/tx_state_store/src/lib.rs
+++ b/tx_state_store/src/lib.rs
@@ -1,0 +1,1 @@
+mod storage;

--- a/tx_state_store/src/storage.rs
+++ b/tx_state_store/src/storage.rs
@@ -1,0 +1,40 @@
+pub mod cassandra;
+
+use std::sync::Arc;
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Error)]
+pub enum Error {
+    #[error("Timeout Error")]
+    Timeout,
+    #[error("Storage Layer error: {0}")]
+    InternalError(Arc<dyn std::error::Error + Send + Sync>),
+}
+
+pub struct CommitInfo {
+    pub epoch: u64,
+}
+
+pub enum OpResult {
+    TransactionIsAborted,
+    TransactionIsCommitted(CommitInfo),
+}
+
+pub trait Storage: Send + Sync + 'static {
+    fn start_transaction(
+        &self,
+        transaction_id: Uuid,
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+    fn abort_transaction(
+        &self,
+        transaction_id: Uuid,
+    ) -> impl std::future::Future<Output = Result<OpResult, Error>> + Send;
+
+    fn commit_transaction(
+        &self,
+        transaction_id: Uuid,
+        epoch: u64,
+    ) -> impl std::future::Future<Output = Result<OpResult, Error>> + Send;
+}

--- a/tx_state_store/src/storage/cassandra.rs
+++ b/tx_state_store/src/storage/cassandra.rs
@@ -1,0 +1,222 @@
+use super::*;
+use scylla::query::Query;
+use scylla::statement::SerialConsistency;
+use scylla::transport::errors::DbError;
+use scylla::transport::errors::QueryError;
+use scylla::transport::PagingState;
+use scylla::Session;
+use scylla::SessionBuilder;
+
+pub struct Cassandra {
+    session: Session,
+}
+
+static START_TRANSACTION_QUERY: &str = r#"
+  INSERT INTO chardonnay.transactions (transaction_id, status) 
+    VALUES (?, 'started') 
+    IF NOT EXISTS
+"#;
+
+static COMMIT_TRANSACTION_QUERY: &str = r#"
+  UPDATE chardonnay.transactions SET status = 'committed', epoch = ?
+    WHERE transaction_id = ? 
+    IF status IN ('started', 'committed')
+"#;
+
+static ABORT_TRANSACTION_QUERY: &str = r#"
+  UPDATE chardonnay.transactions SET status = 'aborted'
+    WHERE transaction_id = ? 
+    IF status IN ('started', 'aborted')
+"#;
+
+static GET_COMMIT_EPOCH_QUERY: &str = r#"
+  SELECT epoch from chardonnay.transactions
+    WHERE transaction_id = ? 
+    AND status = 'committed'
+    ALLOW FILTERING
+"#;
+
+fn scylla_query_error_to_storage_error(qe: QueryError) -> Error {
+    match qe {
+        QueryError::TimeoutError | QueryError::DbError(DbError::WriteTimeout { .. }, _) => {
+            Error::Timeout
+        }
+        _ => Error::InternalError(Arc::new(qe)),
+    }
+}
+
+fn get_serial_query(query_text: impl Into<String>) -> Query {
+    let mut query = Query::new(query_text);
+    query.set_serial_consistency(Some(SerialConsistency::Serial));
+    query
+}
+
+impl Cassandra {
+    pub async fn new(known_node: String) -> Cassandra {
+        let session = SessionBuilder::new()
+            .known_node(known_node)
+            .build()
+            .await
+            .unwrap();
+        Cassandra { session }
+    }
+
+    async fn maybe_get_commit_epoch(&self, transaction_id: Uuid) -> Result<OpResult, Error> {
+        let query = get_serial_query(GET_COMMIT_EPOCH_QUERY);
+        let query_result = self
+            .session
+            .query_single_page(query, (transaction_id,), PagingState::start())
+            .await
+            .map_err(scylla_query_error_to_storage_error)?
+            .0
+            .rows;
+        let res = match query_result {
+            None => Ok(OpResult::TransactionIsAborted),
+            Some(mut rows) => {
+                if rows.len() != 1 {
+                    panic!("found multiple results for a transaction record");
+                } else {
+                    let row = rows.pop().unwrap();
+                    let epoch = row.columns[0].as_ref().unwrap().as_bigint().unwrap();
+                    Ok(OpResult::TransactionIsCommitted(CommitInfo {
+                        epoch: epoch as u64,
+                    }))
+                }
+            }
+        };
+        res
+    }
+}
+
+impl Storage for Cassandra {
+    async fn start_transaction(&self, transaction_id: Uuid) -> Result<(), Error> {
+        let query = get_serial_query(START_TRANSACTION_QUERY);
+        let _ = self
+            .session
+            .query_single_page(query, (transaction_id,), PagingState::start())
+            .await
+            .map_err(scylla_query_error_to_storage_error)?;
+        Ok(())
+    }
+
+    async fn commit_transaction(
+        &self,
+        transaction_id: Uuid,
+        epoch: u64,
+    ) -> Result<OpResult, Error> {
+        let query = get_serial_query(COMMIT_TRANSACTION_QUERY);
+        let query_result = self
+            .session
+            .query_single_page(query, (epoch as i64, transaction_id), PagingState::start())
+            .await
+            .map_err(scylla_query_error_to_storage_error)?
+            .0
+            .rows;
+        let res = match query_result {
+            None => panic!("no results results from a LWT"),
+            Some(mut rows) => {
+                if rows.len() != 1 {
+                    panic!("found multiple results from a LWT");
+                } else {
+                    let row = rows.pop().unwrap();
+                    let applied = row.columns[0].as_ref().unwrap().as_boolean().unwrap();
+                    if applied {
+                        Ok(OpResult::TransactionIsCommitted(CommitInfo { epoch }))
+                    } else {
+                        Ok(OpResult::TransactionIsAborted)
+                    }
+                }
+            }
+        };
+        res
+    }
+
+    async fn abort_transaction(&self, transaction_id: Uuid) -> Result<OpResult, Error> {
+        let query = get_serial_query(ABORT_TRANSACTION_QUERY);
+        let query_result = self
+            .session
+            .query_single_page(query, (transaction_id,), PagingState::start())
+            .await
+            .map_err(scylla_query_error_to_storage_error)?
+            .0
+            .rows;
+        let res = match query_result {
+            None => panic!("no results results from a LWT"),
+            Some(mut rows) => {
+                if rows.len() != 1 {
+                    panic!("found multiple results from a LWT");
+                } else {
+                    let row = rows.pop().unwrap();
+                    let applied = row.columns[0].as_ref().unwrap().as_boolean().unwrap();
+                    if applied {
+                        Ok(OpResult::TransactionIsAborted)
+                    } else {
+                        // This could be either because the transaction is committed, or the
+                        // row has been deleted (presumed abort).
+                        // Let's check which, and fetch the epoch in case of commit.
+                        self.maybe_get_commit_epoch(transaction_id).await
+                    }
+                }
+            }
+        };
+        res
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+
+    impl Cassandra {
+        async fn create_test() -> Cassandra {
+            Cassandra::new("127.0.0.1:9042".to_string()).await
+        }
+    }
+
+    #[tokio::test]
+    async fn start_commit() {
+        let cassandra = Cassandra::create_test().await;
+        let tx_id = Uuid::new_v4();
+        cassandra.start_transaction(tx_id).await.unwrap();
+        match cassandra.commit_transaction(tx_id, 5).await.unwrap() {
+            OpResult::TransactionIsAborted => panic!("expected transaction to commit"),
+            OpResult::TransactionIsCommitted(c) => assert!(c.epoch == 5),
+        }
+    }
+
+    #[tokio::test]
+    async fn start_abort() {
+        let cassandra = Cassandra::create_test().await;
+        let tx_id = Uuid::new_v4();
+        cassandra.start_transaction(tx_id).await.unwrap();
+        match cassandra.abort_transaction(tx_id).await.unwrap() {
+            OpResult::TransactionIsCommitted(_) => panic!("expected transaction to abort"),
+            OpResult::TransactionIsAborted => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn abort_committed() {
+        let cassandra = Cassandra::create_test().await;
+        let tx_id = Uuid::new_v4();
+        cassandra.start_transaction(tx_id).await.unwrap();
+        cassandra.commit_transaction(tx_id, 5).await.unwrap();
+        match cassandra.abort_transaction(tx_id).await.unwrap() {
+            OpResult::TransactionIsAborted => panic!("expected transaction to commit"),
+            OpResult::TransactionIsCommitted(c) => assert!(c.epoch == 5),
+        }
+    }
+
+    #[tokio::test]
+    async fn commit_aborted() {
+        let cassandra = Cassandra::create_test().await;
+        let tx_id = Uuid::new_v4();
+        cassandra.start_transaction(tx_id).await.unwrap();
+        cassandra.abort_transaction(tx_id).await.unwrap();
+        match cassandra.commit_transaction(tx_id, 6).await.unwrap() {
+            OpResult::TransactionIsCommitted(_) => panic!("expected transaction to abort"),
+            OpResult::TransactionIsAborted => (),
+        }
+    }
+}


### PR DESCRIPTION
A cassandra implementation of the transaction state store, a table in which to store the outcome of transactions (commit / abort) and be able to update via LWT (aka paxos)