### PR TITLE
kubernetes: Add CI test for minikube deployment

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -42,11 +42,6 @@ jobs:
 
   build-docker-images:
     runs-on: ubuntu-latest
-    # docker build -t $RANGESERVER_IMG --target rangeserver .
-    # docker build -t $WARDEN_IMG --target warden .
-    # docker build -t $EPOCH_PUBLISHER_IMG --target epoch_publisher .
-    # docker build -t $EPOCH_IMG --target epoch .
-    # docker build -t $UNIVERSE_IMG --target epoch .
     strategy:
       matrix:
         include:
@@ -55,11 +50,11 @@ jobs:
           - target: warden
             tags: chardonnay-warden:latest
           - target: epoch_publisher
-            tags: epoch-publisher:latest
+            tags: chardonnay-epoch-publisher:latest
           - target: epoch
-            tags: epoch:latest
+            tags: chardonnay-epoch:latest
           - target: universe
-            tags: universe:latest
+            tags: chardonnay-universe:latest
 
     steps:
     - uses: actions/checkout@v3
@@ -78,3 +73,30 @@ jobs:
         push: false
 
   # TODO: Add an action to test deploying Chardonnay on a minikube cluster
+
+  deploy-minikube:
+    runs-on: ubuntu-latest
+    needs: [build-docker-images]
+    steps:
+    - uses: actions/checkout@v3
+      name: Check out the repository code
+
+    - name: Start minikube
+      uses: medyagh/setup-minikube@master
+
+    - name: Build images in minikube
+      run: |
+        eval $(minikube docker-env)
+        docker build -t chardonnay-rangeserver:latest --target rangeserver .
+        docker build -t chardonnay-warden:latest --target warden .
+        docker build -t chardonnay-epoch-publisher:latest --target epoch_publisher .
+        docker build -t chardonnay-epoch:latest --target epoch .
+        docker build -t chardonnay-universe:latest --target universe .
+
+    - name: Deploy and verify Chardonnay
+      run: |
+        cd kubernetes && ./deploy.sh
+
+    - name: Clean up
+      if: always()
+      run: minikube delete

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+import sys
+import time
+import logging
+import argparse
+from subprocess import run, check_output
+
+
+log = logging.getLogger(__name__)
+
+
+CHARDONNAY_NAMESPACE = "chardonnay"
+CHARDONNAY_KEYSPACE = "chardonnay"
+CASSANDRA_KEYSPACE_CQL = "../schema/cassandra/chardonnay/keyspace.cql"
+CASSANDRA_SCHEMA_CQL = "../schema/cassandra/chardonnay/schema.cql"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Deploy chardonnay to K8s")
+    return parser.parse_args()
+
+
+def kubectl_list_namespaces():
+    """List all namespaces in the k8s cluster."""
+    output = check_output(
+        [
+            "kubectl",
+            "get",
+            "namespaces",
+            "-o",
+            "jsonpath='{.items[*].metadata.name}'",
+        ],
+        text=True,
+    )
+    namespaces = output.strip("'").split()
+    return namespaces
+
+
+def check_command_exists(command):
+    """Check if a command exists in the system's PATH."""
+    try:
+        check_output(["which", command], text=True)
+        return True
+    except:
+        return False
+
+
+def read_file_contents(file_path):
+    with open(file_path, "r") as f:
+        return f.read()
+
+
+def preflight_checks():
+    # Check prerequisites:
+    # - kubectl
+    # - connection to k8s cluster
+    # - there's no existing deployment
+    if not check_command_exists("kubectl"):
+        log.fatal("kubectl not found in PATH")
+        sys.exit(1)
+    try:
+        check_output(["kubectl", "get", "nodes"])
+    except:
+        log.fatal("Unable to connect to k8s cluster")
+        sys.exit(1)
+    if CHARDONNAY_NAMESPACE in kubectl_list_namespaces():
+        log.fatal(
+            "Chardonnay already deployed, namespace {} already exists".format(
+                CHARDONNAY_NAMESPACE
+            )
+        )
+        sys.exit(1)
+
+
+def kubectl_apply_and_wait_for_sts(yaml_file: str, statefulset: str, namespace: str):
+    run(["kubectl", "apply", "-f", yaml_file], check=True)
+    run(
+        [
+            "kubectl",
+            "rollout",
+            "status",
+            "--watch",
+            "--timeout=120s",
+            "statefulset",
+            statefulset,
+            "-n",
+            namespace,
+        ],
+        check=True,
+    )
+
+
+def wait_until_cassandra_cql_ready(
+    pod_name: str, namespace: str, retries: int = 10, time_between_retries: int = 15
+):
+    fails = 0
+    while True:
+        try:
+            run(
+                [
+                    "kubectl",
+                    "exec",
+                    "-n",
+                    namespace,
+                    pod_name,
+                    "--",
+                    "cqlsh",
+                    "-e",
+                    "DESCRIBE KEYSPACES",
+                ],
+                check=True,
+            )
+            break
+        except:
+            fails += 1
+            if fails > retries:
+                log.fatal("Cassandra not ready after 10 tries")
+                sys.exit(1)
+            log.info(
+                "Cassandra not ready, retrying in %d seconds", time_between_retries
+            )
+            time.sleep(time_between_retries)
+
+
+def main():
+    # Very simple script to deploy the application to Kubernetes
+    # Mainly for CI tests
+
+    # Steps:
+    # 1. Create namespace.
+    # 2. Deploy Cassandra.
+    # 3. Create keyspace and schema in Cassandra
+    # 4. Deploy the universe manager.
+    # 5. Deploy the epoch service.
+    # 6. Deploy the epoch publisher.
+    # 7. Deploy the warden service.
+    # 8. Deploy the rangemanager.
+
+    global log
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args()
+    preflight_checks()
+
+    log.info("Deploying Chardonnay to Kubernetes")
+
+    log.info("Creating namespace")
+    run(["kubectl", "apply", "-f", "namespace.yaml"], check=True)
+
+    log.info("Deploying Cassandra")
+    kubectl_apply_and_wait_for_sts("cassandra.yaml", "cassandra", CHARDONNAY_NAMESPACE)
+    wait_until_cassandra_cql_ready("cassandra-0", CHARDONNAY_NAMESPACE)
+
+    log.info("Creating Cassandra keyspace")
+    keyspace_cql = read_file_contents(CASSANDRA_KEYSPACE_CQL).strip()
+    run(
+        [
+            "kubectl",
+            "exec",
+            "-n",
+            CHARDONNAY_NAMESPACE,
+            "cassandra-0",
+            "--",
+            "cqlsh",
+            "-e",
+            keyspace_cql,
+        ],
+        check=True,
+    )
+    log.info("Creating Cassandra schema")
+    schema_cql = read_file_contents(CASSANDRA_SCHEMA_CQL).strip()
+    run(
+        [
+            "kubectl",
+            "exec",
+            "-n",
+            CHARDONNAY_NAMESPACE,
+            "cassandra-0",
+            "--",
+            "cqlsh",
+            "-k",
+            CHARDONNAY_KEYSPACE,
+            "-e",
+            schema_cql,
+        ],
+        check=True,
+    )
+
+    log.info("Deploying Universe Manager")
+    kubectl_apply_and_wait_for_sts(
+        "universe.yaml", "chardonnay-universe", CHARDONNAY_NAMESPACE
+    )
+    time.sleep(3)
+
+    log.info("Deploying Epoch Service")
+    kubectl_apply_and_wait_for_sts(
+        "epoch_service.yaml", "chardonnay-epoch", CHARDONNAY_NAMESPACE
+    )
+    time.sleep(3)
+
+    log.info("Deploying Epoch Publisher")
+    kubectl_apply_and_wait_for_sts(
+        "epoch_publisher.yaml", "chardonnay-epoch-publisher", CHARDONNAY_NAMESPACE
+    )
+    time.sleep(3)
+
+    log.info("Deploying Warden Service")
+    kubectl_apply_and_wait_for_sts(
+        "warden.yaml", "chardonnay-warden", CHARDONNAY_NAMESPACE
+    )
+    time.sleep(3)
+
+    log.info("Deploying RangeServer")
+    kubectl_apply_and_wait_for_sts(
+        "rangeserver.yaml", "chardonnay-rangeserver", CHARDONNAY_NAMESPACE
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kubernetes/epoch_publisher.yaml
+++ b/kubernetes/epoch_publisher.yaml
@@ -77,7 +77,7 @@ data:
             "fast_network_addr": "0.0.0.0:50055"
         },
         "universe": {
-            "proto_server_addr": "universe:50056"
+            "proto_server_addr": "chardonnay-universe:50056"
         },
         "epoch": {
             "proto_server_addr": "chardonnay-epoch:50050"

--- a/kubernetes/epoch_service.yaml
+++ b/kubernetes/epoch_service.yaml
@@ -64,7 +64,7 @@ data:
             "fast_network_addr": "0.0.0.0:50055"
         },
         "universe": {
-            "proto_server_addr": "universe:50056"
+            "proto_server_addr": "chardonnay-universe:50056"
         },
         "epoch": {
             "proto_server_addr": "0.0.0.0:50050"

--- a/kubernetes/rangeserver.yaml
+++ b/kubernetes/rangeserver.yaml
@@ -78,7 +78,7 @@ data:
             "fast_network_addr": "0.0.0.0:50055"
         },
         "universe": {
-            "proto_server_addr": "universe:50056"
+            "proto_server_addr": "chardonnay-universe:50056"
         },
         "epoch": {
             "proto_server_addr": "chardonnay-epoch:50050"

--- a/kubernetes/universe.yaml
+++ b/kubernetes/universe.yaml
@@ -2,20 +2,20 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: universe
+  name: chardonnay-universe
   namespace: chardonnay
   labels:
-    app: universe
+    app: chardonnay-universe
 spec:
-  serviceName: "universe"
+  serviceName: chardonnay-universe
   replicas: 1
   selector:
     matchLabels:
-      app: universe
+      app: chardonnay-universe
   template:
     metadata:
       labels:
-        app: universe
+        app: chardonnay-universe
     spec:
       containers:
       - name: universe
@@ -33,28 +33,28 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: universe-config
+          name: chardonnay-universe-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: universe
+  name: chardonnay-universe
   namespace: chardonnay
   labels:
-    app: universe
+    app: chardonnay-universe
 spec:
   ports:
   - port: 50056
     name: grpc
   clusterIP: None
   selector:
-    app: universe
+    app: chardonnay-universe
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: universe-config
+  name: chardonnay-universe-config
   namespace: chardonnay
 data:
   config.json: |

--- a/kubernetes/warden.yaml
+++ b/kubernetes/warden.yaml
@@ -70,7 +70,7 @@ data:
             "fast_network_addr": "0.0.0.0:50055"
         },
         "universe": {
-            "proto_server_addr": "universe:50056"
+            "proto_server_addr": "chardonnay-universe:50056"
         },
         "epoch": {
             "proto_server_addr": "chardonnay-epoch:50050"


### PR DESCRIPTION
Add a new CI test that deploys all of Chardonnay on minikube, component-by-component. In the future, once every component has retry logic, we should switch it to just applying everything all at once. Finally, this is not a 100% proper check, since the components are missing readiness probes. This just checks that they're not crashing, and hopefully that means they're working.

The current CI test also rebuilds the images. We should investigate re-using the images built in the docker-image-build job.