### PR TITLE
Coordinator's RangeClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "rangeclient",
  "strum",
  "tokio",
+ "tokio-util",
  "tx_state_store",
  "uuid 1.10.0",
 ]

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,9 +1,8 @@
 use crate::region::{Region, Zone};
 use core::time;
 use derivative::Derivative;
-use proto::universe::universe_server::Universe;
 use serde::{Deserialize, Serialize};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::ToSocketAddrs;
 use std::vec;
 use std::{
     collections::{HashMap, HashSet},

--- a/common/src/host_info.rs
+++ b/common/src/host_info.rs
@@ -1,9 +1,14 @@
 use std::net::SocketAddr;
 
-#[derive(Clone, Debug)]
-pub struct HostInfo {
-    pub identity: String,
-    pub address: SocketAddr,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+pub struct HostIdentity {
+    pub name: String,
     pub zone: crate::region::Zone,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostInfo {
+    pub identity: HostIdentity,
+    pub address: SocketAddr,
     pub warden_connection_epoch: u64,
 }

--- a/common/src/membership/range_assignment_oracle.rs
+++ b/common/src/membership/range_assignment_oracle.rs
@@ -10,5 +10,8 @@ pub trait RangeAssignmentOracle: Send + Sync + 'static {
         key: Bytes,
     ) -> Option<FullRangeId>;
     async fn host_of_range(&self, range_id: &FullRangeId) -> Option<HostInfo>;
+    /// Requests refreshing the assignment.
+    /// Should be used whenever a host says it does not own the range.
+    fn maybe_refresh_host_of_range(&self, range_id: &FullRangeId);
     // TODO: provide APIs for key ranges / scans
 }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -12,5 +12,6 @@ epoch_reader = { version = "0.1.0", path = "../epoch_reader" }
 rangeclient = { version = "0.1.0", path = "../rangeclient" }
 strum = "0.26.3"
 tokio = "1.40.0"
+tokio-util = "0.7.10"
 tx_state_store = { version = "0.1.0", path = "../tx_state_store" }
 uuid = "1.10.0"

--- a/coordinator/src/rangeclient.rs
+++ b/coordinator/src/rangeclient.rs
@@ -81,6 +81,8 @@ impl RangeClient {
                     }
                 }
             };
+            // TODO(tamer): need to stop the old client, maybe by implementing
+            // drop on the Client struct.
             range_clients.remove(&host_info.identity);
             range_clients.insert(host_info.identity.clone(), client.clone());
         };

--- a/coordinator/src/rangeclient.rs
+++ b/coordinator/src/rangeclient.rs
@@ -1,36 +1,115 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use bytes::Bytes;
 use common::{
-    full_range_id::FullRangeId, membership::range_assignment_oracle::RangeAssignmentOracle,
+    full_range_id::FullRangeId, host_info::HostIdentity,
+    membership::range_assignment_oracle::RangeAssignmentOracle, network::fast_network::FastNetwork,
     record::Record, transaction_info::TransactionInfo,
 };
-use rangeclient::client::{Error, GetResult, PrepareOk};
+use rangeclient::client::{Error, GetResult, PrepareOk, RangeClient as Client};
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 /// RangeClient abstracts away the individual rangeservers and allows users
 /// to reach any range just by using the range id.
 pub struct RangeClient {
     range_assignment_oracle: Arc<dyn RangeAssignmentOracle>,
+    range_clients: RwLock<HashMap<HostIdentity, Arc<Client>>>,
+    fast_network: Arc<dyn FastNetwork>,
+    runtime: tokio::runtime::Handle,
+    cancellation_token: CancellationToken,
 }
 
+// public interface
 impl RangeClient {
     pub async fn get(
         &self,
-        _tx: Arc<TransactionInfo>,
-        _range_id: &FullRangeId,
-        _keys: Vec<Bytes>,
+        tx: Arc<TransactionInfo>,
+        range_id: &FullRangeId,
+        keys: Vec<Bytes>,
     ) -> Result<GetResult, Error> {
-        panic!("unimplemented")
+        let client = self.get_range_client(range_id).await?;
+        client
+            .get(tx, range_id, keys)
+            .await
+            .map_err(|e| self.handle_rangeserver_err(range_id, e))
     }
 
     pub async fn prepare_transaction(
         &self,
-        _tx: Arc<TransactionInfo>,
-        _range_id: &FullRangeId,
-        _has_reads: bool,
-        _writes: &[Record],
-        _deletes: &[Bytes],
+        tx: Arc<TransactionInfo>,
+        range_id: &FullRangeId,
+        has_reads: bool,
+        writes: &[Record],
+        deletes: &[Bytes],
     ) -> Result<PrepareOk, Error> {
-        panic!("unimplemented")
+        let client = self.get_range_client(range_id).await?;
+        client
+            .prepare_transaction(tx, range_id, has_reads, writes, deletes)
+            .await
+            .map_err(|e| self.handle_rangeserver_err(range_id, e))
+    }
+}
+
+impl RangeClient {
+    async fn get_range_client(&self, range_id: &FullRangeId) -> Result<Arc<Client>, Error> {
+        let host_info = match self.range_assignment_oracle.host_of_range(range_id).await {
+            None => return Err(Error::RangeIsNotLoaded),
+            Some(host_info) => host_info,
+        };
+        {
+            // fast-path for common case where we already have a client.
+            let range_clients = self.range_clients.read().await;
+            match range_clients.get(&host_info.identity) {
+                None => (),
+                Some(client) => {
+                    if client.host_info() == host_info {
+                        return Ok(client.clone());
+                    }
+                }
+            };
+        }
+
+        let client = Client::new(self.fast_network.clone(), host_info.clone(), None).await;
+        {
+            let mut range_clients = self.range_clients.write().await;
+            match range_clients.get(&host_info.identity) {
+                None => (),
+                Some(client) => {
+                    if client.host_info() == host_info {
+                        return Ok(client.clone());
+                    }
+                }
+            };
+            range_clients.remove(&host_info.identity);
+            range_clients.insert(host_info.identity.clone(), client.clone());
+        };
+
+        Client::start(
+            client.clone(),
+            self.runtime.clone(),
+            self.cancellation_token.clone(),
+        )
+        .await;
+        Ok(client)
+    }
+
+    fn handle_rangeserver_err(&self, range_id: &FullRangeId, error: Error) -> Error {
+        match error {
+            Error::RangeIsNotLoaded | Error::RangeOwnershipLost => self
+                .range_assignment_oracle
+                .maybe_refresh_host_of_range(range_id),
+            Error::InvalidRequestFormat
+            | Error::RangeDoesNotExist
+            | Error::KeyIsOutOfRange
+            | Error::Timeout
+            | Error::ConnectionClosed
+            | Error::UnknownTransaction
+            | Error::CacheIsFull
+            | Error::PrefetchError
+            | Error::TransactionAborted(_)
+            | Error::InternalError(_) => (),
+        };
+        error
     }
 }

--- a/epoch_publisher/src/client.rs
+++ b/epoch_publisher/src/client.rs
@@ -73,7 +73,7 @@ impl EpochPublisherClient {
         // TODO: gracefully handle malformed messages instead of unwrapping and crashing.
         let req_id = Uuid::new_v4();
         trace!(
-            "issuing read_epoch rpc. Epoch Publisher: {}. req_id: {}",
+            "issuing read_epoch rpc. Epoch Publisher: {:#?}. req_id: {}",
             self.range_server_info.identity,
             req_id
         );
@@ -164,7 +164,7 @@ impl EpochPublisherClient {
                                 }
                             } else {
                                 error!("Epoch Client received a message with an unknown request id. \
-                                    Epoch Publisher: {}", client.range_server_info.identity)
+                                    Epoch Publisher: {:#?}", client.range_server_info.identity)
                             }
                         }
                     }

--- a/epoch_publisher/tests/integration_tests.rs
+++ b/epoch_publisher/tests/integration_tests.rs
@@ -16,7 +16,7 @@ use common::{
         CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig, HostPort,
         RangeServerConfig, RegionConfig, UniverseConfig,
     },
-    host_info::HostInfo,
+    host_info::{HostIdentity, HostInfo},
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},
     region::{Region, Zone},
 };
@@ -118,9 +118,11 @@ fn get_server_host_info(address: SocketAddr) -> HostInfo {
         name: "a".into(),
     };
     HostInfo {
-        identity: identity.clone(),
+        identity: HostIdentity {
+            name: identity.clone(),
+            zone,
+        },
         address,
-        zone,
         warden_connection_epoch: 0,
     }
 }

--- a/epoch_reader/src/reader.rs
+++ b/epoch_reader/src/reader.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
-use common::{config::EpochPublisherSet, host_info::HostInfo, network::fast_network::FastNetwork};
+use common::{
+    config::EpochPublisherSet,
+    host_info::{HostIdentity, HostInfo},
+    network::fast_network::FastNetwork,
+};
 use epoch_publisher::{client::EpochPublisherClient, error::Error};
 use std::net::ToSocketAddrs;
 use tokio::task::JoinSet;
@@ -28,14 +32,17 @@ impl EpochReader {
             .iter()
             .map(|publisher| {
                 let host_info = HostInfo {
-                    identity: publisher.name.clone(),
+                    identity: HostIdentity {
+                        name: publisher.name.clone(),
+                        zone: publisher_set.zone.clone(),
+                    },
                     address: publisher
                         .fast_network_addr
                         .to_socket_addrs()
                         .unwrap()
                         .next()
                         .unwrap(),
-                    zone: publisher_set.zone.clone(),
+
                     warden_connection_epoch: 0,
                 };
                 EpochPublisherClient::new(

--- a/rangeserver/src/error.rs
+++ b/rangeserver/src/error.rs
@@ -16,11 +16,12 @@ pub enum Error {
     KeyIsOutOfRange,
     RangeOwnershipLost,
     Timeout,
+    ConnectionClosed,
     UnknownTransaction,
-    TransactionAborted(TransactionAbortReason),
     CacheIsFull,
-    InternalError(Arc<dyn std::error::Error + Send + Sync>),
     PrefetchError,
+    TransactionAborted(TransactionAbortReason),
+    InternalError(Arc<dyn std::error::Error + Send + Sync>),
 }
 
 impl Error {
@@ -65,6 +66,9 @@ impl Error {
             Self::TransactionAborted(_) => Status::TransactionAborted,
             Self::CacheIsFull => Status::CacheIsFull,
             Self::InternalError(_) => Status::InternalError,
+            // ConnectionClosed is really a client-side error and should not be
+            // returned from the server.
+            Self::ConnectionClosed => Status::InternalError,
             Self::PrefetchError => Status::PrefetchError,
         }
     }

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber;
 
 use common::{
     config::Config,
-    host_info::HostInfo,
+    host_info::{HostIdentity, HostInfo},
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},
     region::{Region, Zone},
 };
@@ -44,11 +44,11 @@ fn main() {
     let server_handle = runtime.spawn(async move {
         let cancellation_token = CancellationToken::new();
         let host_info = get_host_info();
-        let region_config = config.regions.get(&host_info.zone.region).unwrap();
+        let region_config = config.regions.get(&host_info.identity.zone.region).unwrap();
         let publisher_set = region_config
             .epoch_publishers
             .iter()
-            .find(|&s| s.zone == host_info.zone)
+            .find(|&s| s.zone == host_info.identity.zone)
             .unwrap();
         let proto_server_addr = config
             .range_server
@@ -103,9 +103,12 @@ fn get_host_info() -> HostInfo {
         name: "a".into(),
     };
     HostInfo {
-        identity: identity.clone(),
+        identity: HostIdentity {
+            name: identity.clone(),
+            zone,
+        },
         address: "127.0.0.1:50054".parse().unwrap(),
-        zone,
+
         warden_connection_epoch: 0,
     }
 }

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -752,6 +752,7 @@ pub mod tests {
     use common::config::{
         CassandraConfig, EpochConfig, HostPort, RangeServerConfig, RegionConfig, UniverseConfig,
     };
+    use common::host_info::HostIdentity;
     use common::network::for_testing::udp_fast_network::UdpFastNetwork;
     use common::region::{Region, Zone};
     use core::time;
@@ -830,9 +831,11 @@ pub mod tests {
         config.regions.insert(region, region_config);
         let identity: String = "test_server".into();
         let host_info = HostInfo {
-            identity: identity.clone(),
+            identity: HostIdentity {
+                name: identity.clone(),
+                zone,
+            },
             address: "127.0.0.1:50054".parse().unwrap(),
-            zone,
             warden_connection_epoch: epoch_supplier.read_epoch().await.unwrap(),
         };
         let server = Server::new(

--- a/rangeserver/src/warden_handler.rs
+++ b/rangeserver/src/warden_handler.rs
@@ -136,8 +136,8 @@ impl WardenHandler {
         let mut client = WardenClient::connect(addr).await?;
         let registration_request = proto::warden::RegisterRangeServerRequest {
             range_server: Some(proto::warden::HostInfo {
-                identity: host_info.identity.clone(),
-                zone: host_info.zone.name.clone(),
+                identity: host_info.identity.name.clone(),
+                zone: host_info.identity.zone.name.clone(),
                 epoch,
             }),
         };
@@ -200,7 +200,11 @@ impl WardenHandler {
     ) -> Result<oneshot::Receiver<Result<(), WardenErr>>, WardenErr> {
         let mut state = self.state.write().await;
         if let State::NotStarted = state.deref_mut() {
-            match self.config.regions.get(&self.host_info.zone.region) {
+            match self
+                .config
+                .regions
+                .get(&self.host_info.identity.zone.region)
+            {
                 None => return Err("unknown region!".into()),
                 Some(config) => {
                     let (done_tx, done_rx) = oneshot::channel::<Result<(), WardenErr>>();

--- a/warden/src/server.rs
+++ b/warden/src/server.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use common::{
-    host_info::HostInfo,
+    host_info::{HostIdentity, HostInfo},
     region::{Region, Zone},
 };
 use pin_project::{pin_project, pinned_drop};
@@ -51,17 +51,20 @@ impl Warden for WardenServer {
             Some(range_server) => {
                 info!("Registering range server: {}", range_server.identity);
                 let host_info = HostInfo {
-                    identity: range_server.identity,
-                    // todo(purujit): Get the address from the range server.
-                    address: SocketAddr::from(([0, 0, 0, 0], 0)),
-                    zone: Zone {
-                        name: range_server.zone,
-                        // TODO(purujit): Get the region from the range server.
-                        region: Region {
-                            cloud: None,
-                            name: "".to_string(),
+                    identity: HostIdentity {
+                        name: range_server.identity,
+                        zone: Zone {
+                            name: range_server.zone,
+                            // TODO(purujit): Get the region from the range server.
+                            region: Region {
+                                cloud: None,
+                                name: "".to_string(),
+                            },
                         },
                     },
+                    // todo(purujit): Get the address from the range server.
+                    address: SocketAddr::from(([0, 0, 0, 0], 0)),
+
                     warden_connection_epoch: range_server.epoch,
                 };
                 match self


### PR DESCRIPTION
A struct to abstract away the different range server connections, giving the transaction a way to talk to ranges just by ID.