### PR TITLE
Persist assignments to Cassandra

### DIFF
--- a/schema/cassandra/chardonnay/schema.cql
+++ b/schema/cassandra/chardonnay/schema.cql
@@ -4,7 +4,7 @@ CREATE TABLE range_map (
     key_lower_bound_inclusive    blob,
     key_upper_bound_exclusive    blob,
     assignee                     text,
-    PRIMARY KEY  (keyspace_id, range_id)
+    PRIMARY KEY  ((keyspace_id), range_id)
   ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };

--- a/schema/cassandra/chardonnay/schema.cql
+++ b/schema/cassandra/chardonnay/schema.cql
@@ -4,7 +4,7 @@ CREATE TABLE range_map (
     key_lower_bound_inclusive    blob,
     key_upper_bound_exclusive    blob,
     assignee                     text,
-    PRIMARY KEY  ((keyspace_id), range_id)
+    PRIMARY KEY  (keyspace_id, range_id)
   ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };

--- a/warden/src/persistence.rs
+++ b/warden/src/persistence.rs
@@ -77,6 +77,10 @@ static INSERT_INTO_RANGE_LEASE_QUERY: &str = r#"
     IF NOT EXISTS
 "#;
 
+// TODO(purujit): To prevent writes from different Warden servers from clobbering each other,
+// we will ultimately want the Warden to acquire a leader lease,
+// we can then wrap this write into a Cassandra Lightweight Transaction that checks against
+// the lease's sequence number.
 static INSERT_OR_UPDATE_RANGE_ASSIGNMENT_QUERY: &str = r#"
   INSERT INTO chardonnay.range_map(keyspace_id, range_id, key_lower_bound_inclusive, key_upper_bound_exclusive, assignee)
   VALUES (?, ?, ?, ?, ?)


### PR DESCRIPTION
This PR just persists the assignments - it does not read it yet at startup. I am persisting the assignments before notifying the range servers. This prevents cases where range server thinks it owns a range but no client else knows about it. It could still happen that we fail to notify the range server after persisting but that's no different than a range server dying. The next iteration will try to reassign those ranges and fix it up.