### PR TITLE
Jepsen setup for Chardonnay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,62 +41,117 @@ COPY . .
 RUN cargo build --release
 
 ###############################################################################
+# node #################################################################
+###############################################################################
+# This is a arm64 build of jgoerzen/debian-base-minimal:bookworm.
+FROM purujit/chardonnay:debian-base-minimal AS debian-addons
+# TODO: See if bookworm-slim would work.
+FROM debian:bookworm AS node
+
+COPY --from=debian-addons /usr/local/preinit/ /usr/local/preinit/
+COPY --from=debian-addons /usr/local/bin/ /usr/local/bin/
+COPY --from=debian-addons /usr/local/debian-base-setup/ /usr/local/debian-base-setup/
+
+RUN run-parts --exit-on-error --verbose /usr/local/debian-base-setup
+
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
+
+# Basic system stuff
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        apt-transport-https
+
+# Install packages
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        dos2unix openssh-server pwgen
+
+# When run, boot-debian-base will call this script, which does final
+# per-db-node setup stuff.
+ADD setup-jepsen.sh /usr/local/preinit/03-setup-jepsen
+RUN chmod +x /usr/local/preinit/03-setup-jepsen
+# Add a service for systemd to run on startup. See https://medium.com/@benmorel/creating-a-linux-service-with-systemd-611b5c8b91d6
+ADD chardonnay.service /etc/systemd/system/chardonnay.service
+ADD config_for_jepsen.json /etc/chardonnay/config.json
+RUN systemctl enable chardonnay.service
+
+# Configure SSHD
+RUN sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin yes/g" /etc/ssh/sshd_config
+
+# Enable SSH server
+ENV DEBBASE_SSH=enabled
+
+# Install Jepsen deps
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        build-essential bzip2 ca-certificates curl dirmngr dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate lsb-release man man-db netcat-openbsd net-tools ntpdate psmisc python3 rsyslog sudo tar tcpdump unzip vim wget
+
+EXPOSE 22
+
+###############################################################################
 # rangeserver #################################################################
 ###############################################################################
 
-FROM debian:bookworm AS rangeserver
+FROM node AS rangeserver
 
 # Copy the built executable from the builder stage
-COPY --from=builder /chardonnay_build/target/release/rangeserver /usr/bin/rangeserver
+COPY --from=builder /chardonnay_build/target/release/rangeserver /usr/bin/chardonnay
 
-# Set the entrypoint
-ENTRYPOINT ["rangeserver"]
+CMD ["/usr/local/bin/boot-debian-base"]
 
 ###############################################################################
 # warden ######################################################################
 ###############################################################################
 
-FROM debian:bookworm AS warden
+FROM node AS warden
 
 # Copy the built executable from the builder stage
-COPY --from=builder /chardonnay_build/target/release/warden /usr/bin/warden
+COPY --from=builder /chardonnay_build/target/release/warden /usr/bin/chardonnay
 
-# Set the entrypoint
-ENTRYPOINT ["warden"]
+CMD ["/usr/local/bin/boot-debian-base"]
 
 ###############################################################################
 # epoch_publisher #############################################################
 ###############################################################################
 
-FROM debian:bookworm AS epoch_publisher
+FROM node AS epoch_publisher
 
 # Copy the built executable from the builder stage
-COPY --from=builder /chardonnay_build/target/release/epoch_publisher /usr/bin/epoch_publisher
+COPY --from=builder /chardonnay_build/target/release/epoch_publisher /usr/bin/chardonnay
 
-# Set the entrypoint
-ENTRYPOINT ["epoch_publisher"]
+CMD ["/usr/local/bin/boot-debian-base"]
 
 
 ###############################################################################
 # epoch_service ###############################################################
 ###############################################################################
 
-FROM debian:bookworm AS epoch
+FROM node AS epoch
 
 # Copy the built executable from the builder stage
-COPY --from=builder /chardonnay_build/target/release/epoch /usr/bin/epoch
+COPY --from=builder /chardonnay_build/target/release/epoch /usr/bin/chardonnay
 
-# Set the entrypoint
-ENTRYPOINT ["epoch"]
+CMD ["/usr/local/bin/boot-debian-base"]
 
 ###############################################################################
 # universe ####################################################################
 ###############################################################################
 
-FROM debian:bookworm AS universe
+FROM node AS universe
 
 # Copy the built executable from the builder stage
-COPY --from=builder /chardonnay_build/target/release/universe /usr/bin/universe
+COPY --from=builder /chardonnay_build/target/release/universe /usr/bin/chardonnay
 
-# Set the entrypoint
-ENTRYPOINT ["universe"]
+CMD ["/usr/local/bin/boot-debian-base"]
+
+###############################################################################
+# cassandra #################################################################
+###############################################################################
+FROM cassandra:5.0 AS cassandra-client
+ADD schema/cassandra/chardonnay/keyspace.cql /etc/chardonnay/cassandra/keyspace.cql
+ADD schema/cassandra/chardonnay/schema.cql /etc/chardonnay/cassandra/schema.cql
+ADD create_schema.sh /usr/local/bin/create_schema.sh
+RUN chmod +x /usr/local/bin/create_schema.sh
+
+CMD ["/usr/local/bin/create_schema.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # Configuration variables
 ARG RUST_VERSION=1.81
 ARG FLATBUFFERS_VERSION=23.5.26
+# Set BUILD_TYPE to 'jepsen' to build the jepsen-specific version of Chardonnay.
 ARG BUILD_TYPE=release
 
 ###############################################################################
@@ -44,9 +45,8 @@ RUN cargo build --release
 ###############################################################################
 # node-jepsen #################################################################
 ###############################################################################
-# This is a arm64 build of jgoerzen/debian-base-minimal:bookworm.
+# This is a arm64 build of jgoerzen/debian-base-minimal:bookworm pulled from Docker hub.
 FROM purujit/chardonnay:debian-base-minimal AS debian-addons
-# TODO: See if bookworm-slim would work.
 FROM debian:bookworm AS node-jepsen
 
 COPY --from=debian-addons /usr/local/preinit/ /usr/local/preinit/
@@ -88,8 +88,8 @@ RUN apt-get -qy update && \
     apt-get -qy install \
         build-essential bzip2 ca-certificates curl dirmngr dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate lsb-release man man-db netcat-openbsd net-tools ntpdate psmisc python3 rsyslog sudo tar tcpdump unzip vim wget
 
-EXPOSE 22
 CMD ["/usr/local/bin/boot-debian-base"]
+EXPOSE 22
 
 ###############################################################################
 # node-jepsen #################################################################
@@ -100,8 +100,6 @@ FROM debian:bookworm AS node-release
 # node ########################################################################
 ###############################################################################
 FROM node-${BUILD_TYPE} AS node
-
-ENTRYPOINT ["chardonnay"]
 
 ###############################################################################
 # rangeserver #################################################################

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -1,0 +1,15 @@
+RANGESERVER_IMG="chardonnay-rangeserver"
+WARDEN_IMG="chardonnay-warden"
+EPOCH_PUBLISHER_IMG="chardonnay-epoch-publisher"
+EPOCH_IMG="chardonnay-epoch"
+UNIVERSE_IMG="chardonnay-universe"
+CASSANDRA_CLIENT_IMG="chardonnay-cassandra-client"
+
+TAG="latest"
+
+docker build -t "$RANGESERVER_IMG:$TAG" --target rangeserver .
+docker build -t "$WARDEN_IMG:$TAG" --target warden .
+docker build -t "$EPOCH_PUBLISHER_IMG:$TAG" --target epoch_publisher .
+docker build -t "$EPOCH_IMG:$TAG" --target epoch .
+docker build -t "$UNIVERSE_IMG:$TAG" --target universe .
+docker build -t "$CASSANDRA_CLIENT_IMG:$TAG" --target cassandra-client .

--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -3,13 +3,17 @@ WARDEN_IMG="chardonnay-warden"
 EPOCH_PUBLISHER_IMG="chardonnay-epoch-publisher"
 EPOCH_IMG="chardonnay-epoch"
 UNIVERSE_IMG="chardonnay-universe"
+BUILD_TYPE="${BUILD_TYPE:-release}"
 CASSANDRA_CLIENT_IMG="chardonnay-cassandra-client"
 
 TAG="latest"
 
-docker build -t "$RANGESERVER_IMG:$TAG" --target rangeserver .
-docker build -t "$WARDEN_IMG:$TAG" --target warden .
-docker build -t "$EPOCH_PUBLISHER_IMG:$TAG" --target epoch_publisher .
-docker build -t "$EPOCH_IMG:$TAG" --target epoch .
-docker build -t "$UNIVERSE_IMG:$TAG" --target universe .
-docker build -t "$CASSANDRA_CLIENT_IMG:$TAG" --target cassandra-client .
+docker build -t "$RANGESERVER_IMG:$TAG" --target rangeserver --build-arg BUILD_TYPE=$BUILD_TYPE .
+docker build -t "$WARDEN_IMG:$TAG" --target warden --build-arg BUILD_TYPE=$BUILD_TYPE .
+docker build -t "$EPOCH_PUBLISHER_IMG:$TAG" --target epoch_publisher --build-arg BUILD_TYPE=$BUILD_TYPE .
+docker build -t "$EPOCH_IMG:$TAG" --target epoch  --build-arg BUILD_TYPE=$BUILD_TYPE .
+docker build -t "$UNIVERSE_IMG:$TAG" --target universe  --build-arg BUILD_TYPE=$BUILD_TYPE .
+
+if [ "$BUILD_TYPE" = "jepsen" ]; then
+    docker build -t "$CASSANDRA_CLIENT_IMG:$TAG" --target cassandra-client .
+fi

--- a/chardonnay.service
+++ b/chardonnay.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Chardonnay Service
+After=network.target
+StartLimitIntervalSec=0
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+Environment="RUST_BACKTRACE=1"
+ExecStart=/usr/bin/chardonnay
+WorkingDirectory=/etc/chardonnay
+
+[Install]
+WantedBy=multi-user.target

--- a/config_for_jepsen.json
+++ b/config_for_jepsen.json
@@ -1,0 +1,37 @@
+{
+  "range_server": {
+    "range_maintenance_duration": {
+      "secs": 1,
+      "nanos": 0
+    },
+    "proto_server_addr": "0.0.0.0:50054",
+    "fast_network_addr": "0.0.0.0:50055"
+  },
+  "universe": {
+    "proto_server_addr": "chardonnay-universe:50056"
+  },
+  "epoch": {
+    "proto_server_addr": "chardonnay-epoch:50050"
+  },
+  "cassandra": {
+    "cql_addr": "cassandra:9042"
+  },
+  "regions": {
+    "test-region": {
+      "warden_address": "chardonnay-warden:50053",
+      "epoch_publishers": [
+        {
+          "name": "ps1",
+          "zone": "test-region/a",
+          "publishers": [
+            {
+              "name": "ep1",
+              "backend_addr": "chardonnay-epoch-publisher:50051",
+              "fast_network_addr": "chardonnay-epoch-publisher:50052"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/create_schema.sh
+++ b/create_schema.sh
@@ -1,0 +1,3 @@
+cqlsh cassandra 9042 -f /etc/chardonnay/cassandra/keyspace.cql
+cqlsh cassandra 9042 -k chardonnay -f /etc/chardonnay/cassandra/schema.cql
+tail -f /dev/null

--- a/epoch_publisher/src/main.rs
+++ b/epoch_publisher/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
     let ct_clone = cancellation_token.clone();
     let rt_handle = runtime.handle().clone();
     bg_runtime.spawn(async move {
+        // There is a bug here. If startup fails e.g. initial epoch read fails, we never retry.
         server::Server::start(server, fast_network.clone(), rt_handle, ct_clone).await;
     });
 

--- a/epoch_publisher/src/server.rs
+++ b/epoch_publisher/src/server.rs
@@ -41,7 +41,7 @@ impl EpochPublisher for ProtoServer {
         &self,
         request: Request<SetEpochRequest>,
     ) -> Result<Response<SetEpochResponse>, TStatus> {
-        warn!("Setting epoch");
+        info!("Setting epoch");
         let reply = SetEpochResponse {};
         let current_epoch = self.server.epoch.load(SeqCst);
         if current_epoch == 0 {

--- a/setup-jepsen.sh
+++ b/setup-jepsen.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# We add our hostname to the shared volume, so that control can find us
+echo "Adding hostname to shared volume" >> /var/log/jepsen-setup.log
+# We do a little dance to get our hostname (random hex), IP, then use DNS to
+# get a proper container name.
+#HOSTNAME=`hostname`
+#IP=`getent hosts "${HOSTNAME}" | awk '{ print $1 }'`
+#NAME=`dig +short -x "${IP}" | cut -f 1 -d .`
+#echo "${NAME}" >> /var/jepsen/shared/nodes
+echo `hostname` >> /var/jepsen/shared/nodes
+
+# We make sure that root's authorized keys are ready
+echo "Setting up root's authorized_keys" >> /var/log/jepsen-setup.log
+mkdir /root/.ssh
+chmod 700 /root/.ssh
+cp /run/secrets/authorized_keys /root/.ssh/
+chmod 600 /root/.ssh/authorized_keys


### PR DESCRIPTION
I have refactored the docker file to use a separate base layer for jepsen which is still built off of Debian bookworm but has jepsen specific dependencies and configuration installed. I am using a `BUILD_TYPE` arg to isolate the jepsen specific changes.
Also fixed a start up bug in epoch publisher that was preventing this job from coming up if epoch service wasn't already running.