### PR TITLE
Fix many compiler and cargo clippy warnings

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -20,10 +20,6 @@ pub struct HostPort {
 }
 
 impl HostPort {
-    pub fn to_string(&self) -> String {
-        format!("{}:{}", self.host, self.port)
-    }
-
     pub fn from_socket_addr(addr: std::net::SocketAddr) -> Self {
         HostPort {
             host: addr.ip().to_string(),

--- a/common/src/network/for_testing/udp_fast_network.rs
+++ b/common/src/network/for_testing/udp_fast_network.rs
@@ -68,9 +68,9 @@ impl Trait for UdpFastNetwork {
                     }
                     Some(s) => s.send(bytes).unwrap(),
                 };
-                return true;
+                true
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => return false,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => false,
             Err(e) => panic!("UdpFastNetwork encountered IO error: {e}"),
         }
     }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -17,10 +17,10 @@ pub struct Region {
     pub name: String,
 }
 
-impl Into<proto::universe::Region> for Region {
-    fn into(self) -> proto::universe::Region {
+impl From<Region> for proto::universe::Region {
+    fn from(val: Region) -> Self {
         proto::universe::Region {
-            cloud: self.cloud.map(|c| match c {
+            cloud: val.cloud.map(|c| match c {
                 Cloud::Aws => {
                     proto::universe::region::Cloud::PublicCloud(proto::universe::Cloud::Aws.into())
                 }
@@ -32,7 +32,7 @@ impl Into<proto::universe::Region> for Region {
                 }
                 Cloud::Other(s) => proto::universe::region::Cloud::OtherCloud(s),
             }),
-            name: self.name,
+            name: val.name,
         }
     }
 }
@@ -88,10 +88,10 @@ impl FromStr for Region {
             }),
             2 => {
                 let cloud = parts[0].parse::<Cloud>()?;
-                return Ok(Region {
+                Ok(Region {
                     cloud: Some(cloud),
                     name: parts[1].to_string(),
-                });
+                })
             }
             _ => Err("invalid region string".to_string()),
         }
@@ -109,7 +109,7 @@ impl Serialize for Region {
 
 struct RegionStringVisitor;
 
-impl<'de> Visitor<'de> for RegionStringVisitor {
+impl Visitor<'_> for RegionStringVisitor {
     type Value = Region;
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a string representation of the region")
@@ -172,7 +172,7 @@ impl Serialize for Zone {
 
 struct ZoneStringVisitor;
 
-impl<'de> Visitor<'de> for ZoneStringVisitor {
+impl Visitor<'_> for ZoneStringVisitor {
     type Value = Zone;
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a string representation of the zone")

--- a/coordinator/src/rangeclient.rs
+++ b/coordinator/src/rangeclient.rs
@@ -102,10 +102,7 @@ impl RangeClient {
         let existing_client = {
             let client = {
                 let range_clients = self.range_clients.read().await;
-                match range_clients.get(&host_info.identity) {
-                    None => None,
-                    Some(c) => Some(c.clone()),
-                }
+                range_clients.get(&host_info.identity).cloned()
             };
             match client {
                 None => None,

--- a/coordinator/src/transaction.rs
+++ b/coordinator/src/transaction.rs
@@ -192,7 +192,7 @@ impl Transaction {
                 panic!("transaction committed without coordinator consent!")
             }
         }
-        while let Some(_) = abort_join_set.join_next().await {}
+        while abort_join_set.join_next().await.is_some() {}
         Ok(())
     }
 
@@ -309,7 +309,7 @@ impl Transaction {
                 &self.runtime,
             );
         }
-        while let Some(_) = commit_join_set.join_next().await {}
+        while commit_join_set.join_next().await.is_some() {}
         Ok(())
     }
 

--- a/epoch/src/publisher_set_updater.rs
+++ b/epoch/src/publisher_set_updater.rs
@@ -66,10 +66,7 @@ impl PublisherSetUpdater {
                 }
                 Ok(res) => res,
             };
-            match res {
-                Err(_) => continue,
-                Ok(_) => (),
-            };
+            if let Err(_) = res { continue };
             num_success += 1;
             if num_success >= self.publisher_majority_count {
                 return Ok(());

--- a/epoch/src/publisher_set_updater.rs
+++ b/epoch/src/publisher_set_updater.rs
@@ -66,7 +66,9 @@ impl PublisherSetUpdater {
                 }
                 Ok(res) => res,
             };
-            if let Err(_) = res { continue };
+            if res.is_err() {
+                continue;
+            }
             num_success += 1;
             if num_success >= self.publisher_majority_count {
                 return Ok(());

--- a/epoch/src/storage/cassandra.rs
+++ b/epoch/src/storage/cassandra.rs
@@ -74,7 +74,8 @@ impl Storage for Cassandra {
             .map_err(scylla_query_error_to_storage_error)?
             .rows;
 
-        let res = match rows {
+        
+        match rows {
             None => Err(Error::EpochNotInitialized),
             Some(mut rows) => {
                 if rows.len() != 1 {
@@ -85,8 +86,7 @@ impl Storage for Cassandra {
                     Ok(epoch as u64)
                 }
             }
-        };
-        res
+        }
     }
 
     async fn conditional_update(&self, new_epoch: u64, current_epoch: u64) -> Result<(), Error> {

--- a/epoch_publisher/src/client.rs
+++ b/epoch_publisher/src/client.rs
@@ -124,7 +124,7 @@ impl EpochPublisherClient {
     fn create_and_serialize_read_epoch_request(&self, req_id: &Uuid) -> Bytes {
         // TODO: too much copying :(
         let mut fbb = FlatBufferBuilder::new();
-        let request_id = Some(Uuidu128::create(&mut fbb, &serialize_uuid(req_id.clone())));
+        let request_id = Some(Uuidu128::create(&mut fbb, &serialize_uuid(*req_id)));
         let fbb_root = ReadEpochRequest::create(&mut fbb, &ReadEpochRequestArgs { request_id });
         fbb.finish(fbb_root, None);
         let get_request_bytes = Bytes::copy_from_slice(fbb.finished_data());
@@ -141,7 +141,7 @@ impl EpochPublisherClient {
         loop {
             let () = tokio::select! {
                 () = cancellation_token.cancelled() => {
-                    return ()
+                    return 
                 }
                 maybe_message = network_receiver.recv() => {
                     match maybe_message {

--- a/epoch_publisher/src/for_testing/mock_epoch.rs
+++ b/epoch_publisher/src/for_testing/mock_epoch.rs
@@ -28,6 +28,12 @@ pub struct MockEpoch {
     state: Arc<State>,
 }
 
+impl Default for MockEpoch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockEpoch {
     pub fn new() -> MockEpoch {
         let state = Arc::new(State {

--- a/epoch_publisher/src/main.rs
+++ b/epoch_publisher/src/main.rs
@@ -2,7 +2,6 @@ use std::{net::ToSocketAddrs, sync::Arc};
 
 use common::config::Config;
 use std::net::UdpSocket;
-use tracing_subscriber;
 
 use common::{
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},

--- a/epoch_publisher/src/server.rs
+++ b/epoch_publisher/src/server.rs
@@ -164,7 +164,7 @@ impl Server {
         loop {
             let () = tokio::select! {
                 () = cancellation_token.cancelled() => {
-                    return ()
+                    return 
                 }
                 maybe_message = network_receiver.recv() => {
                     match maybe_message {

--- a/epoch_publisher/src/server.rs
+++ b/epoch_publisher/src/server.rs
@@ -85,7 +85,7 @@ impl Server {
             ),
             Some(request_id) => {
                 let epoch = self.epoch.load(SeqCst);
-                let status = if epoch <= 0 {
+                let status = if epoch == 0 {
                     Status::EpochUnknown
                 } else {
                     Status::Ok
@@ -164,7 +164,7 @@ impl Server {
         loop {
             let () = tokio::select! {
                 () = cancellation_token.cancelled() => {
-                    return 
+                    return
                 }
                 maybe_message = network_receiver.recv() => {
                     match maybe_message {

--- a/epoch_publisher/tests/integration_tests.rs
+++ b/epoch_publisher/tests/integration_tests.rs
@@ -79,7 +79,7 @@ async fn setup_server(
     epoch_address: SocketAddr,
 ) -> tokio::runtime::Runtime {
     let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
-    let fast_network_addr = server_socket.local_addr().unwrap().clone();
+    let fast_network_addr = server_socket.local_addr().unwrap();
     let fast_network = Arc::new(UdpFastNetwork::new(server_socket));
     let fast_network_clone = fast_network.clone();
     let runtime_clone = runtime.handle().clone();
@@ -155,7 +155,7 @@ async fn setup_client(
         get_server_host_info(server_address),
         cancellation_token.clone(),
     );
-    return (client, runtime, bg_runtime);
+    (client, runtime, bg_runtime)
 }
 
 async fn setup(initial_epoch: u64) -> TestContext {

--- a/flatbuf/Cargo.toml
+++ b/flatbuf/Cargo.toml
@@ -8,3 +8,7 @@ flatc-rust = "*"
 
 [dependencies]
 flatbuffers = "24.3.25"
+
+[lints.rust]
+# The generated flatbuffers code triggers a bunch of benign and unactionable compiler warnings.
+warnings = "allow"

--- a/universe/src/server.rs
+++ b/universe/src/server.rs
@@ -1,35 +1,14 @@
-use std::{
-    net::SocketAddr,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::sync::Arc;
 
-use common::{
-    host_info::{self, HostInfo},
-    keyspace_id,
-    region::{self, Region, Zone},
-};
-use pin_project::{pin_project, pinned_drop};
-use proto::universe::universe_client::UniverseClient;
 use proto::universe::universe_server::Universe;
 use proto::universe::{
     CreateKeyspaceRequest, CreateKeyspaceResponse, ListKeyspacesRequest, ListKeyspacesResponse,
 };
-use tokio::sync::broadcast;
-use tokio_stream::{
-    wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
-    Stream,
-};
-use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 use tracing::{debug, info, instrument};
 use uuid::Uuid;
 
-use crate::storage::{
-    cassandra::{self, Cassandra},
-    Storage,
-};
+use crate::storage::Storage;
 
 /// Implementation of the Universe manager.
 pub struct UniverseServer<S: Storage> {

--- a/universe/src/storage.rs
+++ b/universe/src/storage.rs
@@ -1,4 +1,4 @@
-use proto::universe::{KeyRange, KeyRangeRequest, KeyspaceInfo, Zone};
+use proto::universe::{KeyRange, KeyspaceInfo, Zone};
 use std::sync::Arc;
 use thiserror::Error;
 

--- a/universe/src/storage/cassandra.rs
+++ b/universe/src/storage/cassandra.rs
@@ -122,7 +122,7 @@ impl SerializedKeyspaceInfo {
     }
 
     /// Convert into a KeyspaceInfo proto.
-    fn to_keyspace_info(self) -> KeyspaceInfo {
+    fn into_keyspace_info(self) -> KeyspaceInfo {
         let primary_zone = Zone {
             name: self.primary_zone.name,
             region: self
@@ -238,7 +238,7 @@ impl Storage for Cassandra {
             .map(|row| {
                 let serialized = row.into_typed::<SerializedKeyspaceInfo>();
                 serialized
-                    .map(SerializedKeyspaceInfo::to_keyspace_info)
+                    .map(SerializedKeyspaceInfo::into_keyspace_info)
                     .map_err(|e| Error::InternalError(Some(Arc::new(e))))
             })
             .collect::<Result<Vec<KeyspaceInfo>, Error>>()?;
@@ -324,7 +324,7 @@ mod tests {
                 })
                 .collect(),
         );
-        let roundtrip = serialized.to_keyspace_info();
+        let roundtrip = serialized.into_keyspace_info();
         assert!(original == roundtrip);
     }
 

--- a/universe/src/storage/cassandra.rs
+++ b/universe/src/storage/cassandra.rs
@@ -91,9 +91,9 @@ impl SerializedKeyspaceInfo {
         base_key_range_requests: Vec<KeyRange>,
     ) -> Self {
         SerializedKeyspaceInfo {
-            keyspace_id: keyspace_id,
-            name: name,
-            namespace: namespace,
+            keyspace_id,
+            name,
+            namespace,
             primary_zone: SerializedZone {
                 name: primary_zone.name,
                 region: primary_zone.region.map(|region| SerializedRegion {
@@ -207,7 +207,7 @@ impl Storage for Cassandra {
         println!("Query result: {:?}", query_result);
         // If the first row of the result is true, our insert was successful.
         // Else, insert failed, thus the keyspace already exists.
-        if let Some(Some(insert_succeeded)) = query_result.0.first_row().unwrap().columns.get(0) {
+        if let Some(Some(insert_succeeded)) = query_result.0.first_row().unwrap().columns.first() {
             if !insert_succeeded.as_boolean().unwrap() {
                 return Err(Error::KeyspaceAlreadyExists);
             }
@@ -278,8 +278,8 @@ mod tests {
     ) -> KeyspaceInfo {
         KeyspaceInfo {
             keyspace_id: Uuid::new_v4().to_string(),
-            name: name,
-            namespace: namespace,
+            name,
+            namespace,
             primary_zone: Some(Zone {
                 region: Some(Region {
                     name: region_name,
@@ -325,7 +325,7 @@ mod tests {
                 .collect(),
         );
         let roundtrip = serialized.to_keyspace_info();
-        assert_eq!(original == roundtrip, true);
+        assert!(original == roundtrip);
     }
 
     #[tokio::test]
@@ -380,7 +380,7 @@ mod tests {
                 .find(|k| k.keyspace_id == keyspace_id)
                 .unwrap_or_else(|| panic!("Keyspace with id {} was not found", keyspace_id));
 
-            assert_eq!(original == roundtrip, true);
+            assert!(original == roundtrip);
         }
 
         let this_region_keyspace_id = keyspace_ids[0].clone();

--- a/universe/src/storage/cassandra.rs
+++ b/universe/src/storage/cassandra.rs
@@ -252,8 +252,7 @@ impl Storage for Cassandra {
                     keyspace
                         .primary_zone
                         .as_ref()
-                        .and_then(|zone| zone.region.as_ref())
-                        .map_or(false, |keyspace_region| keyspace_region == &filter_region)
+                        .and_then(|zone| zone.region.as_ref()) == Some(&filter_region)
                 })
                 .collect()
         } else {

--- a/universe/tests/integration_tests.rs
+++ b/universe/tests/integration_tests.rs
@@ -28,7 +28,7 @@ async fn test_create_and_list_keyspace_handlers() {
         .unwrap();
 
     // Create a keyspace
-    let keyspace_name = format!("test_keyspace_{}", Uuid::new_v4().to_string());
+    let keyspace_name = format!("test_keyspace_{}", Uuid::new_v4());
     let namespace = "test_namespace";
     let primary_zone = Some(proto::universe::Zone {
         region: Some(proto::universe::Region {
@@ -47,8 +47,8 @@ async fn test_create_and_list_keyspace_handlers() {
     let keyspace_req = CreateKeyspaceRequest {
         name: keyspace_name.to_string(),
         namespace: namespace.to_string(),
-        primary_zone: primary_zone,
-        base_key_ranges: base_key_ranges,
+        primary_zone,
+        base_key_ranges,
     };
     let keyspace_id = client
         .create_keyspace(keyspace_req)


### PR DESCRIPTION
This PR fixes many but not all of the compiler and clippy warnings without disabling warnings or making functional changes to the code. The only exception is that I've disabled warnings for generated flatbuffers code since we have little to no control over the generated code.

- Unused imports are removed
- Dead code is deliberately left as-is
- Certain sub-folders are left as-is and will be addressed in a separate PR

**Each commit is meant to stand alone. Rebase and merge, don't squash the PR.**