### PR TITLE
Fix most "trivial" compiler warnings and clippy lints for rangeserver/

### DIFF
--- a/rangeserver/src/error.rs
+++ b/rangeserver/src/error.rs
@@ -38,7 +38,7 @@ impl Error {
         match e {
             WalError::Timeout => Self::Timeout,
             WalError::NotSynced => Self::RangeOwnershipLost,
-            WalError::InternalError(e) => Self::InternalError(e),
+            WalError::Internal(e) => Self::InternalError(e),
         }
     }
 

--- a/rangeserver/src/for_testing/epoch_supplier.rs
+++ b/rangeserver/src/for_testing/epoch_supplier.rs
@@ -39,6 +39,12 @@ pub struct EpochSupplier {
     state: RwLock<State>,
 }
 
+impl Default for EpochSupplier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EpochSupplier {
     pub fn new() -> EpochSupplier {
         EpochSupplier {

--- a/rangeserver/src/for_testing/in_memory_wal.rs
+++ b/rangeserver/src/for_testing/in_memory_wal.rs
@@ -34,6 +34,20 @@ pub struct InMemIterator<'a> {
 }
 
 impl<'a> Iterator<'a> for InMemIterator<'a> {
+    async fn next(&mut self) -> Option<LogEntry<'_>> {
+        let wal = self.wal.state.lock().await;
+        let ind = (wal.first_offset.unwrap_or(0) + self.index) as usize;
+        if ind >= wal.entries.len() {
+            return None;
+        }
+        self.current_entry = Some(wal.entries.get(ind).unwrap().clone());
+
+        self.index += 1;
+        self.current_entry
+            .as_ref()
+            .map(|e| root_as_log_entry(e).unwrap())
+    }
+
     async fn next_offset(&self) -> Result<u64, Error> {
         let wal = self.wal.state.lock().await;
         match wal.first_offset {
@@ -44,20 +58,11 @@ impl<'a> Iterator<'a> for InMemIterator<'a> {
             }
         }
     }
+}
 
-    async fn next(&mut self) -> Option<LogEntry<'_>> {
-        let wal = self.wal.state.lock().await;
-        let ind = (wal.first_offset.unwrap_or(0) + self.index) as usize;
-        if ind >= wal.entries.len() {
-            return None;
-        }
-        self.current_entry = Some(wal.entries.get(ind).unwrap().clone());
-
-        self.index += 1;
-        match &self.current_entry {
-            None => None,
-            Some(e) => Some(root_as_log_entry(e).unwrap()),
-        }
+impl Default for InMemoryWal {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -88,15 +93,6 @@ impl Wal for InMemoryWal {
         let wal = self.state.lock().await;
         let len_u64 = wal.entries.len() as u64;
         Ok(wal.first_offset.unwrap_or(0) + len_u64)
-    }
-
-    async fn trim_before_offset(&self, offset: u64) -> Result<(), Error> {
-        let mut wal = self.state.lock().await;
-        while wal.entries.len() > 0 && wal.first_offset.unwrap_or(0) < offset {
-            wal.entries.pop_front();
-            wal.first_offset = Some(wal.first_offset.unwrap_or(0) + 1);
-        }
-        Ok(())
     }
 
     async fn append_prepare(&self, entry: PrepareRequest<'_>) -> Result<(), Error> {
@@ -141,7 +137,16 @@ impl Wal for InMemoryWal {
         state.append_data_currently_in_builder()
     }
 
-    fn iterator<'a>(&'a self) -> InMemIterator<'a> {
+    async fn trim_before_offset(&self, offset: u64) -> Result<(), Error> {
+        let mut wal = self.state.lock().await;
+        while !wal.entries.is_empty() && wal.first_offset.unwrap_or(0) < offset {
+            wal.entries.pop_front();
+            wal.first_offset = Some(wal.first_offset.unwrap_or(0) + 1);
+        }
+        Ok(())
+    }
+
+    fn iterator(&self) -> InMemIterator {
         InMemIterator {
             index: 0,
             wal: self,

--- a/rangeserver/src/for_testing/mock_warden.rs
+++ b/rangeserver/src/for_testing/mock_warden.rs
@@ -34,6 +34,12 @@ fn range_id_proto(range: &FullRangeId) -> proto::warden::RangeId {
     }
 }
 
+impl Default for MockWarden {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockWarden {
     pub fn new() -> MockWarden {
         let warden_state = Arc::new(WardenState {

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -2,7 +2,6 @@ use std::{
     net::{ToSocketAddrs, UdpSocket},
     sync::Arc,
 };
-use tracing_subscriber;
 
 use common::{
     config::Config,

--- a/rangeserver/src/range_manager/impl.rs
+++ b/rangeserver/src/range_manager/impl.rs
@@ -176,7 +176,7 @@ where
                         .prefetching_buffer
                         .get_from_buffer(key.clone())
                         .await
-                        .map_err(|_| return Error::PrefetchError)?;
+                        .map_err(|_| Error::PrefetchError)?;
                     if let Some(val) = value {
                         get_result.val = Some(val);
                     } else {
@@ -306,7 +306,7 @@ where
                     return Ok(());
                 }
                 state.highest_known_epoch =
-                    std::cmp::max(state.highest_known_epoch, commit.epoch() as u64);
+                    std::cmp::max(state.highest_known_epoch, commit.epoch());
                 // TODO: handle potential duplicates here.
                 self.wal
                     .append_commit(commit)
@@ -321,7 +321,7 @@ where
                 let prepare_record =
                     flatbuffers::root::<PrepareRequest>(&prepare_record_bytes).unwrap();
                 let version = KeyVersion {
-                    epoch: commit.epoch() as u64,
+                    epoch: commit.epoch(),
                     // TODO: version counter should be an internal counter per range.
                     // Remove from the commit message.
                     version_counter: commit.vid() as u64,
@@ -421,7 +421,7 @@ where
         let epoch_supplier = self.epoch_supplier.clone();
         let storage = self.storage.clone();
         let wal = self.wal.clone();
-        let range_id = self.range_id.clone();
+        let range_id = self.range_id;
         let bg_runtime = self.bg_runtime.clone();
         let state = self.state.clone();
         let lease_renewal_interval = self.config.range_server.range_maintenance_duration;

--- a/rangeserver/src/wal.rs
+++ b/rangeserver/src/wal.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("Timeout")]
     Timeout,
     #[error("WAL Layer error: {0}")]
-    InternalError(Arc<dyn std::error::Error + Send + Sync>),
+    Internal(Arc<dyn std::error::Error + Send + Sync>),
 }
 
 pub trait Iterator<'a> {
@@ -38,5 +38,5 @@ pub trait Wal: Send + Sync + 'static {
     async fn append_abort(&self, entry: AbortRequest<'_>) -> Result<(), Error>;
     async fn trim_before_offset(&self, offset: u64) -> Result<(), Error>;
 
-    fn iterator<'a>(&'a self) -> impl Iterator + Send;
+    fn iterator(&self) -> impl Iterator + Send;
 }

--- a/rangeserver/src/wal/cassandra.rs
+++ b/rangeserver/src/wal/cassandra.rs
@@ -39,7 +39,7 @@ fn scylla_query_error_to_wal_error(qe: QueryError) -> Error {
         QueryError::TimeoutError | QueryError::DbError(DbError::WriteTimeout { .. }, _) => {
             Error::Timeout
         }
-        _ => Error::InternalError(Arc::new(qe)),
+        _ => Error::Internal(Arc::new(qe)),
     }
 }
 
@@ -110,7 +110,7 @@ impl CassandraWal {
                 log_state.flatbuf_builder.reset();
 
                 let write_id = Uuid::new_v4();
-                let offset = log_state.next_offset;
+                let offset: i64 = log_state.next_offset;
                 log_state.next_offset += 1;
                 log_state.first_offset = Some(log_state.first_offset.unwrap_or(offset));
 
@@ -124,9 +124,9 @@ impl CassandraWal {
                         log_state.first_offset,
                         self.wal_id,
                         METADATA_OFFSET,
-                        offset as i64,
+                        offset
                     ),
-                    (self.wal_id, offset as i64, content, write_id),
+                    (self.wal_id, offset, content, write_id),
                 );
                 self.session
                     .batch(&batch, batch_args)
@@ -252,7 +252,7 @@ impl Wal for CassandraWal {
         self.append_entry(Entry::Commit, entry._tab.buf()).await
     }
 
-    fn iterator<'a>(&'a self) -> InMemIterator<'a> {
+    fn iterator(&self) -> InMemIterator {
         todo!()
     }
 }

--- a/rangeserver/src/warden_handler.rs
+++ b/rangeserver/src/warden_handler.rs
@@ -90,7 +90,7 @@ impl WardenHandler {
 
                 // Load any ranges that got newly assigned to us.
                 for assigned_range in &new_assignment {
-                    if !assigned_ranges.contains(&assigned_range) {
+                    if !assigned_ranges.contains(assigned_range) {
                         updates_sender
                             .send(WardenUpdate::LoadRange(*assigned_range))
                             .unwrap();
@@ -205,7 +205,7 @@ impl WardenHandler {
                 .regions
                 .get(&self.host_info.identity.zone.region)
             {
-                None => return Err("unknown region!".into()),
+                None => Err("unknown region!".into()),
                 Some(config) => {
                     let (done_tx, done_rx) = oneshot::channel::<Result<(), WardenErr>>();
                     let host_info = self.host_info.clone();


### PR DESCRIPTION
There are still other lints to fix which require more careful consideration.

This includes changes such as:

- Reordering Trait funtion implementations
- Replacing match with if let where applicable
- Replacing with assert!(x == y) with assert_eq!(x, y)
- Removing unused imports
- Implementing Default for types with trivial new() functions
- Removing unnecessary return statements
- Using shorthand syntax for creating structs

... and more