### PR TITLE
epoch: Enforce the monotonic epoch property for the Cassandra backend

### DIFF
--- a/epoch/src/storage/cassandra.rs
+++ b/epoch/src/storage/cassandra.rs
@@ -89,6 +89,9 @@ impl Storage for Cassandra {
     }
 
     async fn conditional_update(&self, new_epoch: u64, current_epoch: u64) -> Result<(), Error> {
+        if new_epoch < current_epoch {
+            return Err(Error::ConditionFailed);
+        }
         let utcnow = chrono::Utc::now();
         let mut query = Query::new(UPDATE_EPOCH_QUERY);
         query.set_serial_consistency(Some(SerialConsistency::Serial));


### PR DESCRIPTION
Before this commit epoch::Storage::conditional_update allowed the epoch to be moved backwards. This probably should be disallowed since the epoch should increase monotonically.