### PR TITLE
epoch: Add assertions to conditional_update test

### DIFF
--- a/epoch/tests/storage_test.rs
+++ b/epoch/tests/storage_test.rs
@@ -123,8 +123,7 @@ async fn epoch_increases_monotonically(mut storage: StorageTestCase) {
     storage.setup().await;
 
     storage.initialize_epoch().await.unwrap();
-    let epoch = storage.read_latest().await.unwrap();
-    assert_eq!(epoch, 1);
+    assert_eq!(storage.read_latest().await.unwrap(), 1);
     let err = storage
         .conditional_update(/*new_epoch=*/ 0, /*current_epoch=*/ 1)
         .await
@@ -133,7 +132,9 @@ async fn epoch_increases_monotonically(mut storage: StorageTestCase) {
         Error::ConditionFailed => (),
         _ => panic!("unexpected error: {:?}", err),
     }
-
+    // The epoch shouldn't have changed.
+    assert_eq!(storage.read_latest().await.unwrap(), 1);
+    
     storage.teardown().await;
 }
 
@@ -149,8 +150,7 @@ async fn low_epoch_conditional_update(mut storage: StorageTestCase) {
         .conditional_update(/*new_epoch=*/ 2, /*current_epoch=*/ 1)
         .await
         .expect("conditional update should succeed");
-    let epoch = storage.read_latest().await.unwrap();
-    assert_eq!(epoch, 2);
+    assert_eq!(storage.read_latest().await.unwrap(), 2);
 
     // Attempt an update where the epoch is behind by one.
     match storage
@@ -161,6 +161,8 @@ async fn low_epoch_conditional_update(mut storage: StorageTestCase) {
         Ok(_) => panic!("stale current epoch should not succeed"),
         _ => panic!("unexpected error"),
     }
+    // The epoch shouldn't have changed.
+    assert_eq!(storage.read_latest().await.unwrap(), 2);
 
     storage.teardown().await;
 }
@@ -172,8 +174,7 @@ async fn high_epoch_conditional_update(mut storage: StorageTestCase) {
     storage.setup().await;
 
     storage.initialize_epoch().await.unwrap();
-    let epoch = storage.read_latest().await.unwrap();
-    assert_eq!(epoch, 1);
+    assert_eq!(storage.read_latest().await.unwrap(), 1);
 
     // Attempt an update where the epoch is ahead by one.
     match storage
@@ -184,6 +185,8 @@ async fn high_epoch_conditional_update(mut storage: StorageTestCase) {
         Ok(_) => panic!("high current epoch should not succeed"),
         _ => panic!("unexpected error"),
     }
+    // The epoch shouldn't have changed.
+    assert_eq!(storage.read_latest().await.unwrap(), 1);
 
     storage.teardown().await;
 }


### PR DESCRIPTION
This commit:

- Adds assertions that the epoch hasn't changed unexpectedly in the high and low conditional_update tests.
- Removes the local `epoch` variable from some of the tests for conciseness.