### PR TITLE
epoch: Add an in-memory implementation of the epoch::Storage trait

### DIFF
--- a/epoch/src/storage.rs
+++ b/epoch/src/storage.rs
@@ -1,4 +1,5 @@
 pub mod cassandra;
+pub mod in_memory;
 
 use std::sync::Arc;
 use thiserror::Error;
@@ -20,7 +21,7 @@ pub trait Storage: Send + Sync + 'static {
     fn initialize_epoch(&self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
     fn read_latest(&self) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
     /// Sets the value of the epoch to [new_epoch], but only if the current value is
-    /// [current_epoch].
+    /// [current_epoch]. Since 0 indicates an uninitialized epoch, [new_epoch] cannot be 0.
     fn conditional_update(
         &self,
         new_epoch: u64,

--- a/epoch/src/storage/in_memory.rs
+++ b/epoch/src/storage/in_memory.rs
@@ -1,0 +1,53 @@
+use super::Error;
+use super::Storage;
+use std::sync::atomic;
+
+#[derive(Debug)]
+pub struct InMemoryEpochStorage {
+    // The current epoch, where 0 means that the epoch hasn't been initialized yet.
+    epoch: atomic::AtomicU64,
+}
+
+impl InMemoryEpochStorage {
+    pub fn new() -> InMemoryEpochStorage {
+        InMemoryEpochStorage {
+            epoch: atomic::AtomicU64::new(0),
+        }
+    }
+}
+
+impl Storage for InMemoryEpochStorage {
+    async fn initialize_epoch(&self) -> Result<(), Error> {
+        // Try to initialize the epoch. If it's already been initialized, the compare exchange will
+        // fail, which is ok. Relaxed ordering is sufficient since there is no dependent data.
+        self.epoch
+            .compare_exchange(0, 1, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+            .ok();
+        Ok(())
+    }
+
+    async fn read_latest(&self) -> Result<u64, Error> {
+        // Relaxed ordering is sufficient since there is no dependent data.
+        let epoch = self.epoch.load(atomic::Ordering::Relaxed);
+        if epoch == 0 {
+            return Err(Error::EpochNotInitialized);
+        }
+        Ok(epoch)
+    }
+
+    async fn conditional_update(&self, new_epoch: u64, current_epoch: u64) -> Result<(), Error> {
+        if new_epoch < current_epoch {
+            return Err(Error::ConditionFailed);
+        }
+        // Relaxed ordering is sufficient since there is no dependent data.
+        match self.epoch.compare_exchange(
+            current_epoch,
+            new_epoch,
+            atomic::Ordering::Relaxed,
+            atomic::Ordering::Relaxed,
+        ) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(Error::ConditionFailed),
+        }
+    }
+}


### PR DESCRIPTION
This allows for light-weight testing without Cassandra.

This commit also documents that an epoch value of 0 is invalid and represents that the epoch storage hasn't been initialized yet. I believe this was true before this commit, but just wasn't documented.